### PR TITLE
Fix bug readdir & readdirplus reply only first items.

### DIFF
--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -157,7 +157,7 @@ macro_rules! handle_dir_read {
                 },
             };
 
-            let mut new_offset = $offset + 1;
+            let mut new_offset = $offset;
 
             // ### Process directory entries
             if_readdir!(
@@ -166,9 +166,10 @@ macro_rules! handle_dir_read {
                     // readdir: Add entries until buffer is full
                     while let Some((name, ino, kind)) = dir_iter.pop_front() {
                         if $reply.add(ino, new_offset, kind, &name) {
+                            dir_iter.push_front((name, ino, kind));
                             dirmap_iter
                                 .safe_borrow_mut()
-                                .insert(($ino, new_offset), dir_iter);
+                                .insert(($ino, new_offset - 1), dir_iter);
                             break;
                         }
                         new_offset += 1;
@@ -188,9 +189,10 @@ macro_rules! handle_dir_read {
                             &fuse_attr,
                             generation.unwrap_or(get_random_generation()),
                         ) {
+                            dir_iter.push_front((name, ino, file_attr));
                             dirmap_iter
                                 .safe_borrow_mut()
-                                .insert((ino, new_offset), dir_iter);
+                                .insert((ino, new_offset - 1), dir_iter);
                             break;
                         }
                         new_offset += 1;

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -180,16 +180,16 @@ macro_rules! handle_dir_read {
                     // readdirplus: Add entries with extended attributes
                     let default_ttl = handler.get_default_ttl();
                     while let Some((name, ino, file_attr)) = dir_iter.pop_front() {
-                        let (fuse_attr, ttl, generation) = file_attr.to_fuse(ino);
+                        let (fuse_attr, ttl, generation) = file_attr.clone().to_fuse(ino);
                         if $reply.add(
                             ino,
                             new_offset,
-                            name,
+                            &name,
                             &ttl.unwrap_or(default_ttl),
                             &fuse_attr,
                             generation.unwrap_or(get_random_generation()),
                         ) {
-                            dir_iter.push_front((name, ino, file_attr));
+                            dir_iter.push_front((name, ino, file_attr.clone()));
                             dirmap_iter
                                 .safe_borrow_mut()
                                 .insert((ino, new_offset - 1), dir_iter);


### PR DESCRIPTION
When a client attempted to read a directory, the functions readdir and readdirplus would only yield the initial items in the directory. This incomplete response could cause issues for applications expecting to receive a full listing of files and subdirectories. 