### PR TITLE
feat: Add a manual pruning mechanism to the resolver

### DIFF
--- a/src/core/fuse_driver.rs
+++ b/src/core/fuse_driver.rs
@@ -217,6 +217,7 @@ where
         let resolver = self.get_resolver();
         handler.forget(&req, resolver.resolve_id(ino), nlookup);
         resolver.forget(ino, nlookup);
+        handler.prune_resolver(self.get_resolver());
     }
 
     fn fsync(&mut self, req: &Request, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {

--- a/src/core/inode_mapping.rs
+++ b/src/core/inode_mapping.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     ffi::{OsStr, OsString},
     path::PathBuf,
     sync::atomic::Ordering,
@@ -63,6 +64,7 @@ pub trait FileIdResolver: Send + Sync + 'static {
         increment: bool,
     ) -> Vec<(OsString, u64)>;
     fn forget(&self, ino: u64, nlookup: u64);
+    fn prune(&self, keep: &HashSet<Self::ResolvedType>);
     fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr);
 }
 
@@ -97,6 +99,8 @@ impl FileIdResolver for InodeResolver {
     }
 
     fn forget(&self, _ino: u64, _nlookup: u64) {}
+
+    fn prune(&self, _keep: &HashSet<Self::ResolvedType>) {}
 
     fn rename(&self, _parent: u64, _name: &OsStr, _newparent: u64, _newname: &OsStr) {}
 }
@@ -198,6 +202,10 @@ impl FileIdResolver for ComponentsResolver {
         self.mapper.write().unwrap().remove(&inode).unwrap();
     }
 
+    fn prune(&self, keep: &HashSet<Self::ResolvedType>) {
+        self.mapper.write().expect("Failed to acquire write lock").prune(keep);
+    }
+
     fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr) {
         let parent_inode = Inode::from(parent);
         let newparent_inode = Inode::from(newparent);
@@ -256,6 +264,14 @@ impl FileIdResolver for PathResolver {
 
     fn forget(&self, ino: u64, nlookup: u64) {
         self.resolver.forget(ino, nlookup);
+    }
+
+    fn prune(&self, keep: &HashSet<Self::ResolvedType>) {
+        let resolver_keep: HashSet<Vec<OsString>> = keep
+            .iter()
+            .map(|path| path.iter().map(|s| s.to_os_string()).collect())
+            .collect();
+        self.resolver.prune(&resolver_keep);
     }
 
     fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr) {

--- a/src/fuse_handler.rs
+++ b/src/fuse_handler.rs
@@ -92,6 +92,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::types::*;
+use crate::core::inode_mapping::InodeResolvable;
 
 mod private {
     #[cfg(not(feature = "serial"))]
@@ -108,6 +109,9 @@ use private::OptionalSendSync;
 pub trait FuseHandler<TId: FileIdType>: OptionalSendSync + 'static {
     /// Delegate unprovided methods to another FuseHandler, enabling composition
     fn get_inner(&self) -> &dyn FuseHandler<TId>;
+
+    /// Prune the resolver by removing unreferenced inodes
+    fn prune_resolver(&self, _resolver: &<TId as InodeResolvable>::Resolver) {}
 
     /// Provide a default Time-To-Live for file metadata
     ///

--- a/src/inode_mapper.rs
+++ b/src/inode_mapper.rs
@@ -1,10 +1,11 @@
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::hash::Hash;
 use std::sync::Arc;
 
 use super::{Inode, ROOT_INODE};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Helper structure for managing inodes and their relationships.
 ///
@@ -534,6 +535,34 @@ impl<T: Send + Sync + 'static> InodeMapper<T> {
             Some(inode_value.data)
         } else {
             None
+        }
+    }
+}
+
+impl InodeMapper<AtomicU64> {
+    pub fn prune(&mut self, keep: &HashSet<Vec<OsString>>) {
+        let mut to_remove = Vec::new();
+
+        for (inode, value) in &self.data.inodes {
+            if *inode == ROOT_INODE {
+                continue;
+            }
+            if value.data.load(Ordering::SeqCst) == 0 {
+                // Check if path is in keep list
+                if let Some(path_info) = self.resolve(inode) {
+                    // path_info is [leaf, parent...]
+                    // We need [parent, leaf]
+                    let path_vec: Vec<OsString> =
+                        path_info.iter().rev().map(|info| (**info.name).clone()).collect();
+                    if !keep.contains(&path_vec) {
+                        to_remove.push(inode.clone());
+                    }
+                }
+            }
+        }
+
+        for inode in to_remove {
+            self.remove(&inode);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces an optional mechanism for handlers to manually prune the inode resolver cache. This helps mitigate issues where inode mappings could be prematurely evicted under heavy workloads, leading to "Failed to resolve inode" panics.

_The Problem_

 Under certain conditions, such as rename-heavy workloads, the FUSE kernel may not issue forget calls for all inodes in a timely manner. If the resolver evicts an inode that is still referenced by the kernel, subsequent operations on that inode will fail.

_The Solution_

This change introduces a new, handler-driven pruning mechanism as a safeguard:

1. `prune()` API: A new prune(&self, keep: &HashSet<...>) method has been added to the FileIdResolver trait. This method allows for the removal of unreferenced inode mappings. Its implementation in InodeMapper iterates through inodes, removing any whose lookup count is zero and whose path is not present in the provided keep set.

2. `prune_resolver()` Hook: A corresponding prune_resolver() method has been added to the FuseHandler trait. This allows the filesystem implementation to decide when to trigger the pruning process and which inodes to preserve (e.g., those with open file handles).

This provides a way for filesystem authors to implement more robust cache-cleaning logic tailored to their specific needs, thereby improving stability.

