### PR TITLE
Fix compilation on musl Linux and add CI check

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -72,3 +72,21 @@ jobs:
         PKG_CONFIG_ALLOW_CROSS: 1
         PKG_CONFIG_PATH: /usr/lib/i386-linux-gnu/pkgconfig
       run: cargo check --target=i686-unknown-linux-gnu --features parallel
+
+  check_musl:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    name: "Check musl compilation"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install musl-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools
+    - name: Setup Rust
+      run: |
+        rustup update stable
+        rustup default stable
+        rustup target add x86_64-unknown-linux-musl
+    - name: Check
+      run: cargo check --target=x86_64-unknown-linux-musl --features parallel

--- a/src/unix_fs/linux_fs.rs
+++ b/src/unix_fs/linux_fs.rs
@@ -23,7 +23,21 @@ pub(super) unsafe fn renameat2(
     newpath: *const c_char,
     flags: c_uint,
 ) -> c_int {
-    unsafe { libc::renameat2(olddirfd, oldpath, newdirfd, newpath, flags) }
+    #[cfg(target_env = "gnu")]
+    unsafe {
+        libc::renameat2(olddirfd, oldpath, newdirfd, newpath, flags)
+    }
+    #[cfg(not(target_env = "gnu"))]
+    unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            olddirfd,
+            oldpath,
+            newdirfd,
+            newpath,
+            flags,
+        ) as c_int
+    }
 }
 
 pub(super) unsafe fn fdatasync(fd: c_int) -> c_int {


### PR DESCRIPTION
This PR fixes a compilation error on musl-based Linux platforms (like Alpine) where `libc::renameat2` is not available in the `libc` crate. It falls back to using a direct system call for these platforms. Additionally, it adds a new CI job to verify that the project continues to compile for the `x86_64-unknown-linux-musl` target.

---
*PR created automatically by Jules for task [15271947911957342796](https://jules.google.com/task/15271947911957342796) started by @Alogani*