### PR TITLE
Refactor DeviceType and mknod implementation review

### DIFF
--- a/src/types/arguments.rs
+++ b/src/types/arguments.rs
@@ -19,7 +19,6 @@ use std::time::{Duration, SystemTime};
 
 use fuser::FileAttr as FuseFileAttr;
 use fuser::{FileType, Request, TimeOrNow};
-use libc::mode_t;
 
 use super::BorrowedFileHandle;
 use super::LockType;
@@ -63,40 +62,29 @@ pub enum DeviceType {
 }
 
 impl DeviceType {
-    pub fn from_rdev(rdev: mode_t) -> Self {
-        use libc::*;
-        // Extract major and minor device numbers (assuming the device number format).
-        let major: u32 = (rdev >> 8).into(); // Major is the upper part of the 32-bit value (16 bit on macos)
-        let minor: u32 = (rdev & 0xFF).into(); // Minor is the lower 8 bits
-        match rdev {
-            x if x & S_IFREG != 0 => DeviceType::RegularFile,
-            x if x & S_IFDIR != 0 => DeviceType::Directory,
-            x if x & S_IFCHR != 0 => DeviceType::CharacterDevice { major, minor },
-            x if x & S_IFBLK != 0 => DeviceType::BlockDevice { major, minor },
-            x if x & S_IFIFO != 0 => DeviceType::NamedPipe,
-            x if x & S_IFSOCK != 0 => DeviceType::Socket,
-            x if x & S_IFLNK != 0 => DeviceType::Symlink,
-            _ => DeviceType::Unknown,
+    pub fn from_file_type_and_rdev(file_type: FileType, rdev: libc::dev_t) -> Self {
+        let major: u32 = libc::major(rdev) as u32;
+        let minor: u32 = libc::minor(rdev) as u32;
+        match file_type {
+            FileType::RegularFile => DeviceType::RegularFile,
+            FileType::Directory => DeviceType::Directory,
+            FileType::CharDevice => DeviceType::CharacterDevice { major, minor },
+            FileType::BlockDevice => DeviceType::BlockDevice { major, minor },
+            FileType::NamedPipe => DeviceType::NamedPipe,
+            FileType::Socket => DeviceType::Socket,
+            FileType::Symlink => DeviceType::Symlink,
         }
     }
 
-    pub fn to_rdev(&self) -> mode_t {
-        use libc::*;
-
+    pub fn to_rdev(&self) -> libc::dev_t {
         match self {
-            DeviceType::RegularFile => S_IFREG,
-            DeviceType::Directory => S_IFDIR,
-            DeviceType::CharacterDevice { major, minor } => {
-                let device = ((major & 0xFF) << 8) | (minor & 0xFF);
-                (device as mode_t) | S_IFCHR
-            }
-            DeviceType::BlockDevice { major, minor } => {
-                let device = ((major & 0xFF) << 8) | (minor & 0xFF);
-                (device as mode_t) | S_IFBLK
-            }
-            DeviceType::NamedPipe => S_IFIFO,
-            DeviceType::Socket => S_IFSOCK,
-            DeviceType::Symlink => S_IFLNK,
+            DeviceType::RegularFile => 0,
+            DeviceType::Directory => 0,
+            DeviceType::CharacterDevice { major, minor } => libc::makedev(*major, *minor),
+            DeviceType::BlockDevice { major, minor } => libc::makedev(*major, *minor),
+            DeviceType::NamedPipe => 0,
+            DeviceType::Socket => 0,
+            DeviceType::Symlink => 0,
             DeviceType::Unknown => 0, // Represents an unknown device
         }
     }

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -209,6 +209,12 @@ impl ErrorKind {
     }
 }
 
+impl Into<i32> for PosixError {
+    fn into(self) -> i32 {
+        self.code
+    }
+}
+
 impl From<i32> for ErrorKind {
     fn from(code: i32) -> Self {
         match code {

--- a/src/unix_fs.rs
+++ b/src/unix_fs.rs
@@ -132,7 +132,7 @@ fn convert_stat_struct(statbuf: libc::stat) -> Option<FileAttribute> {
         mtime,
         ctime,
         crtime: mtime,
-        kind: stat_to_kind(statbuf)?,
+        kind: mode_to_kind(statbuf.st_mode as u32)?,
         perm: perm,
         nlink: statbuf.st_nlink as u32,
         uid: statbuf.st_uid as u32,
@@ -145,16 +145,15 @@ fn convert_stat_struct(statbuf: libc::stat) -> Option<FileAttribute> {
     })
 }
 
-fn stat_to_kind(statbuf: libc::stat) -> Option<FileKind> {
-    use libc::*;
-    Some(match statbuf.st_mode & S_IFMT {
-        S_IFREG => FileKind::RegularFile,
-        S_IFDIR => FileKind::Directory,
-        S_IFCHR => FileKind::CharDevice,
-        S_IFBLK => FileKind::BlockDevice,
-        S_IFIFO => FileKind::NamedPipe,
-        S_IFLNK => FileKind::Symlink,
-        S_IFSOCK => FileKind::Socket,
+pub(crate) fn mode_to_kind(mode: u32) -> Option<FileKind> {
+    Some(match mode as libc::mode_t & libc::S_IFMT {
+        libc::S_IFREG => FileKind::RegularFile,
+        libc::S_IFDIR => FileKind::Directory,
+        libc::S_IFCHR => FileKind::CharDevice,
+        libc::S_IFBLK => FileKind::BlockDevice,
+        libc::S_IFIFO => FileKind::NamedPipe,
+        libc::S_IFLNK => FileKind::Symlink,
+        libc::S_IFSOCK => FileKind::Socket,
         _ => return None, // Unsupported or unknown file type
     })
 }

--- a/templates/fuse_driver.rs.j2
+++ b/templates/fuse_driver.rs.j2
@@ -17,6 +17,7 @@ use fuser::{
     ReplyStatfs, ReplyWrite, ReplyXattr, Request, TimeOrNow,
 };
 
+use crate::unix_fs;
 use crate::fuse_handler::FuseHandler;
 use crate::types::*;
 use crate::core::helpers::*;
@@ -708,13 +709,22 @@ where
         let resolver = self.resolver.clone();
         let name = name.to_owned();
         {% call spawn() %}
+            let file_kind = match unix_fs::mode_to_kind(mode) {
+                Some(file_kind) => file_kind,
+                None => {
+                    {% call spawn_reply() %}
+                        reply.error(PosixError::new(ErrorKind::InvalidArgument, "unknown file kind").into());
+                    {% endcall %}
+                    return;
+                }
+            };
             match handler.mknod(
                 &req,
                 resolver.resolve_id(parent),
                 &name,
                 mode,
                 umask,
-                DeviceType::from_rdev(rdev.try_into().unwrap())
+                DeviceType::from_file_type_and_rdev(file_kind, rdev.try_into().unwrap())
             ) {
                 {% call reply_entry("parent", "name") %}{% endcall %}
                 Err(e) => {


### PR DESCRIPTION
I have thoroughly reviewed and verified the PR. It correctly refactors the handling of device nodes and file types, which was previously based on a flawed assumption about the `rdev` field.

Key improvements:
- Correct separation of file kind (from mode bits) and device ID (rdev).
- Standardized use of `libc` macros for device numbers.
- Improved error handling for FUSE replies.

I've also fixed a small bug in the template (missing import) and optimized the `DeviceType` conversion to be more idiomatic. All unit tests pass.

---
*PR created automatically by Jules for task [12835782722344334841](https://jules.google.com/task/12835782722344334841) started by @Alogani*