### PR TITLE
104 bumping dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy_fuser"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "A flexible and idiomatic Fuse implementation for Rust"
 license = "MIT"
@@ -18,8 +18,8 @@ libfuse = ["fuser/libfuse"]
 
 [dependencies]
 # Core dependencies
-easy_fuser_macro = { version = "0.1", path = "easy_fuser_macro"}
-fuser = { version = "0.16.0" }
+easy_fuser_macro = { version = "0.1.1", path = "easy_fuser_macro"}
+fuser = { version = "0.17.0" }
 log = "0.4"
 libc = "0.2"
 bitflags = "2.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ easy_fuser_macro = { version = "0.1", path = "easy_fuser_macro"}
 fuser = { version = "0.16.0" }
 log = "0.4"
 libc = "0.2"
-bitflags = "2.10"
+bitflags = "2.13"
 
 # Parallel dependencies
 threadpool = { version = "1.8", optional = true }
@@ -31,16 +31,16 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"], optional = 
 
 # Async dependencies
 # easy_fuser_async_macro = { path = "./easy_fuser_async_macro", optional = true }
-tokio = { version = "1.48", features = ["full"], optional = true }
+tokio = { version = "1.52", features = ["full"], optional = true }
 async-trait = { version = "0.1.89", optional = true }
 bimap = { version = "0.6.3", features = ["std"] }
 
 [dev-dependencies]
-tempfile = "3.23"
+tempfile = "3.27"
 env_logger = "0.11"
 
 [build-dependencies]
-askama = { version = "0.15.4", features = ["derive"] }
+askama = { version = "0.16.0", features = ["derive"] }
 
 [package.metadata.docs.rs]
 features = ["parallel"]

--- a/easy_fuser_macro/Cargo.toml
+++ b/easy_fuser_macro/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 syn =  {version = "2.0", features = [ "full" ] }
 quote = "1.0"
 proc-macro2 = "1.0"
-either = "1.15.0"
+either = "1.16"

--- a/easy_fuser_macro/Cargo.toml
+++ b/easy_fuser_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy_fuser_macro"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Procedural macros for the easy_fuser crate"
 license = "MIT"

--- a/easy_fuser_macro/src/fuse_handlers_signatures.rs
+++ b/easy_fuser_macro/src/fuse_handlers_signatures.rs
@@ -12,7 +12,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
             fn destroy(&self);
         },
         "access" => parse_quote! {
-            fn access(&self, req: &RequestInfo, file_id: Self::TId, mask: AccessMask) -> FuseResult<()>;
+            fn access(&self, req: &RequestInfo, file_id: Self::TId, mask: AccessFlags) -> FuseResult<()>;
         },
         "bmap" => parse_quote! {
             fn bmap(
@@ -29,12 +29,12 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 req: &RequestInfo,
                 file_in: Self::TId,
                 file_handle_in: BorrowedFileHandle<'_>,
-                offset_in: i64,
+                offset_in: u64,
                 file_out: Self::TId,
                 file_handle_out: BorrowedFileHandle<'_>,
-                offset_out: i64,
+                offset_out: u64,
                 len: u64,
-                flags: u32, // Not implemented yet in standard
+                flags: CopyFileRangeFlags,
             ) -> FuseResult<u32>;
         },
         "create" => parse_quote! {
@@ -46,7 +46,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 mode: u32,
                 umask: u32,
                 flags: OpenFlags,
-            ) -> FuseResult<(OwnedFileHandle, <Self::TId as FileIdType>::Metadata, FUSEOpenResponseFlags)>;
+            ) -> FuseResult<(OwnedFileHandle, <Self::TId as FileIdType>::Metadata, FopenFlags)>;
         },
         "fallocate" => parse_quote! {
             fn fallocate(
@@ -122,7 +122,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 req: &RequestInfo,
                 file_id: Self::TId,
                 file_handle: BorrowedFileHandle<'_>,
-                flags: IOCtlFlags,
+                flags: IoctlFlags,
                 cmd: u32,
                 in_data: Vec<u8>,
                 out_size: u32,
@@ -184,7 +184,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 req: &RequestInfo,
                 file_id: Self::TId,
                 flags: OpenFlags,
-            ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)>;
+            ) -> FuseResult<(OwnedFileHandle, FopenFlags)>;
         },
         "opendir" => parse_quote! {
             fn opendir(
@@ -192,7 +192,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 req: &RequestInfo,
                 file_id: Self::TId,
                 flags: OpenFlags,
-            ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)>;
+            ) -> FuseResult<(OwnedFileHandle, FopenFlags)>;
         },
         "read" => parse_quote! {
             fn read(
@@ -202,7 +202,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 file_handle: BorrowedFileHandle<'_>,
                 seek: SeekFrom,
                 size: u32,
-                flags: FUSEOpenFlags,
+                flags: OpenFlags,
                 lock_owner: Option<u64>,
             ) -> FuseResult<Vec<u8>>;
         },
@@ -288,7 +288,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 file_id: Self::TId,
                 name: &std::ffi::OsStr,
                 value: Vec<u8>,
-                flags: FUSESetXAttrFlags,
+                flags: SetXAttrFlags,
                 position: u32,
             ) -> FuseResult<()>;
         },
@@ -312,7 +312,7 @@ pub fn get_fuse_handler_trait_fn(func_name: &str) -> TraitItemFn {
                 file_handle: BorrowedFileHandle<'_>,
                 seek: SeekFrom,
                 data: Vec<u8>,
-                write_flags: FUSEWriteFlags,
+                write_flags: WriteFlags,
                 flags: OpenFlags,
                 lock_owner: Option<u64>,
             ) -> FuseResult<u32>;

--- a/examples/ftp_fs/src/filesystem.rs
+++ b/examples/ftp_fs/src/filesystem.rs
@@ -85,7 +85,7 @@ impl FuseHandler for FtpFs {
         _file_handle: BorrowedFileHandle,
         offset: SeekFrom,
         size: u32,
-        _flags: FUSEOpenFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
         self.with_ftp(|ftp| {

--- a/examples/hello_fs/src/main.rs
+++ b/examples/hello_fs/src/main.rs
@@ -33,7 +33,7 @@ const HELLO_DIR_ATTR: (Inode, FileAttribute) = (
 const HELLO_TXT_CONTENT: &str = "Hello World!\n";
 
 const HELLO_TXT_ATTR: (Inode, FileAttribute) = (
-    Inode::from(2),
+    INodeNo(2),
     FileAttribute {
         size: 13,
         blocks: 1,
@@ -112,7 +112,7 @@ impl FuseHandler for HelloFS {
         _file_handle: BorrowedFileHandle,
         seek: SeekFrom,
         size: u32,
-        _flags: FUSEOpenFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
         if file_id == HELLO_TXT_ATTR.0 {

--- a/examples/in_memory_fs/src/filesystem.rs
+++ b/examples/in_memory_fs/src/filesystem.rs
@@ -26,7 +26,7 @@ impl InMemoryFS {
     pub fn new() -> Self {
         let mut fs = DataBank {
             inodes: HashMap::new(),
-            next_inode: Inode::from(2), // Root is 1
+            next_inode: INodeNo(2), // Root is 1
         };
 
         // Create root directory
@@ -72,7 +72,7 @@ impl FuseHandler for InMemoryFS {
     ] }
 
     // Access is not called for every operation
-    fn access(&self, req: &RequestInfo, file_id: Inode, mask: AccessMask) -> FuseResult<()> {
+    fn access(&self, req: &RequestInfo, file_id: Inode, mask: AccessFlags) -> FuseResult<()> {
         let fs = self.fs.lock().unwrap();
         let node = fs
             .inodes
@@ -88,54 +88,54 @@ impl FuseHandler for InMemoryFS {
             return Ok(());
         }
 
-        let mut allowed_mask = AccessMask::empty();
+        let mut allowed_mask = AccessFlags::empty();
 
         // Owner permissions
         if req.uid == file_uid {
             if file_mode & 0o400 != 0 {
-                allowed_mask |= AccessMask::CAN_READ;
+                allowed_mask |= AccessFlags::R_OK;
             }
             if file_mode & 0o200 != 0 {
-                allowed_mask |= AccessMask::CAN_WRITE;
+                allowed_mask |= AccessFlags::W_OK;
             }
             if file_mode & 0o100 != 0 {
-                allowed_mask |= AccessMask::CAN_EXEC;
+                allowed_mask |= AccessFlags::X_OK;
             }
         }
         // Group permissions
         else if req.gid == file_gid {
             if file_mode & 0o040 != 0 {
-                allowed_mask |= AccessMask::CAN_READ;
+                allowed_mask |= AccessFlags::R_OK;
             }
             if file_mode & 0o020 != 0 {
-                allowed_mask |= AccessMask::CAN_WRITE;
+                allowed_mask |= AccessFlags::W_OK;
             }
             if file_mode & 0o010 != 0 {
-                allowed_mask |= AccessMask::CAN_EXEC;
+                allowed_mask |= AccessFlags::X_OK;
             }
         }
         // Others permissions
         else {
             if file_mode & 0o004 != 0 {
-                allowed_mask |= AccessMask::CAN_READ;
+                allowed_mask |= AccessFlags::R_OK;
             }
             if file_mode & 0o002 != 0 {
-                allowed_mask |= AccessMask::CAN_WRITE;
+                allowed_mask |= AccessFlags::W_OK;
             }
             if file_mode & 0o001 != 0 {
-                allowed_mask |= AccessMask::CAN_EXEC;
+                allowed_mask |= AccessFlags::X_OK;
             }
         }
 
         // Special cases for directories
         if node.attr.kind == FileKind::Directory {
             // Always need execute permission to access a directory
-            if !allowed_mask.contains(AccessMask::CAN_EXEC) {
+            if !allowed_mask.contains(AccessFlags::X_OK) {
                 return Err(ErrorKind::PermissionDenied
                     .to_error("Execute permission required for directory"));
             }
             // Writing to a directory means adding or removing entries, which requires write permission
-            if mask.contains(AccessMask::CAN_WRITE) && !allowed_mask.contains(AccessMask::CAN_WRITE)
+            if mask.contains(AccessFlags::W_OK) && !allowed_mask.contains(AccessFlags::W_OK)
             {
                 return Err(ErrorKind::PermissionDenied
                     .to_error("Write permission required for directory modification"));
@@ -161,11 +161,11 @@ impl FuseHandler for InMemoryFS {
         (
             OwnedFileHandle,
             (Inode, FileAttribute),
-            FUSEOpenResponseFlags,
+            FopenFlags,
         ),
         PosixError,
     > {
-        self.access(req, parent.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, parent.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
         let new_inode = fs.next_inode.clone();
         if let Some(parent_node) = fs.inodes.get_mut(&parent) {
@@ -205,7 +205,7 @@ impl FuseHandler for InMemoryFS {
                 // Safe because we won't release it
                 unsafe { OwnedFileHandle::from_raw(0) },
                 (new_inode.clone(), attr),
-                FUSEOpenResponseFlags::empty(),
+                FopenFlags::empty(),
             ))
         } else {
             Err(ErrorKind::FileNotFound.to_error(""))
@@ -221,7 +221,7 @@ impl FuseHandler for InMemoryFS {
         length: i64,
         mode: FallocateFlags,
     ) -> FuseResult<()> {
-        self.access(req, file_id.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, file_id.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
 
         if let Some(node) = fs.inodes.get_mut(&file_id) {
@@ -296,7 +296,7 @@ impl FuseHandler for InMemoryFS {
         parent: Inode,
         name: &OsStr,
     ) -> FuseResult<(Inode, FileAttribute)> {
-        self.access(req, parent.clone(), AccessMask::CAN_READ)?;
+        self.access(req, parent.clone(), AccessFlags::R_OK)?;
         let fs = self.fs.lock().unwrap();
         if let Some(parent_node) = fs.inodes.get(&parent) {
             if let Some(child_inode) = parent_node.children.get(name) {
@@ -316,7 +316,7 @@ impl FuseHandler for InMemoryFS {
         mode: u32,
         _umask: u32,
     ) -> FuseResult<(Inode, FileAttribute)> {
-        self.access(req, parent.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, parent.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
         let new_inode = fs.next_inode.clone();
         if let Some(parent_node) = fs.inodes.get_mut(&parent) {
@@ -365,10 +365,10 @@ impl FuseHandler for InMemoryFS {
         _fh: BorrowedFileHandle,
         offset: SeekFrom,
         size: u32,
-        _flags: FUSEOpenFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
-        self.access(req, ino.clone(), AccessMask::CAN_READ)?;
+        self.access(req, ino.clone(), AccessFlags::R_OK)?;
         let fs = self.fs.lock().unwrap();
         if let Some(node) = fs.inodes.get(&ino) {
             let offset = match offset {
@@ -391,7 +391,7 @@ impl FuseHandler for InMemoryFS {
         ino: Inode,
         _fh: BorrowedFileHandle,
     ) -> FuseResult<Vec<(OsString, (Inode, FileKind))>> {
-        self.access(req, ino.clone(), AccessMask::CAN_READ)?;
+        self.access(req, ino.clone(), AccessFlags::R_OK)?;
         let fs = self.fs.lock().unwrap();
         if let Some(node) = fs.inodes.get(&ino) {
             let mut entries = vec![
@@ -420,8 +420,8 @@ impl FuseHandler for InMemoryFS {
         newname: &OsStr,
         flags: RenameFlags,
     ) -> FuseResult<()> {
-        self.access(req, parent_id.clone(), AccessMask::CAN_WRITE)?;
-        self.access(req, newparent.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, parent_id.clone(), AccessFlags::W_OK)?;
+        self.access(req, newparent.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
 
         // Check if the source exists and get its inode
@@ -439,7 +439,7 @@ impl FuseHandler for InMemoryFS {
             .and_then(|parent| parent.children.get(newname).cloned());
 
         if let Some(existing_dest) = existing_dest {
-            if flags.contains(RenameFlags::NOREPLACE) {
+            if flags.contains(RenameFlags::RENAME_NOREPLACE) {
                 return Err(ErrorKind::FileExists.to_error("Destination already exists"));
             }
             // If REPLACE flag is set or no flags, remove the existing destination
@@ -471,7 +471,7 @@ impl FuseHandler for InMemoryFS {
     }
 
     fn rmdir(&self, req: &RequestInfo, parent_id: Inode, name: &OsStr) -> FuseResult<()> {
-        self.access(req, parent_id.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, parent_id.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
 
         // Check if the dir to remove exists and get its inode
@@ -579,11 +579,11 @@ impl FuseHandler for InMemoryFS {
         _fh: BorrowedFileHandle,
         offset: SeekFrom,
         data: Vec<u8>,
-        _write_flags: FUSEWriteFlags,
+        _write_flags: WriteFlags,
         _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<u32> {
-        self.access(req, ino.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, ino.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
         if let Some(node) = fs.inodes.get_mut(&ino) {
             let offset = match offset {
@@ -603,7 +603,7 @@ impl FuseHandler for InMemoryFS {
     }
 
     fn unlink(&self, req: &RequestInfo, parent_id: Inode, name: &OsStr) -> FuseResult<()> {
-        self.access(req, parent_id.clone(), AccessMask::CAN_WRITE)?;
+        self.access(req, parent_id.clone(), AccessFlags::W_OK)?;
         let mut fs = self.fs.lock().unwrap();
 
         if let Some(child_inode) = fs.inodes.get_mut(&parent_id).unwrap().children.remove(name) {

--- a/examples/in_memory_fs/src/main.rs
+++ b/examples/in_memory_fs/src/main.rs
@@ -15,7 +15,7 @@ fn create_memory_fs() -> InMemoryFS {
     {
         // An example of interacting directly with the filesystem
         let request_info = RequestInfo {
-            id: 0,
+            id: RequestId(0),
             uid: 0,
             gid: 0,
             pid: 0,
@@ -27,7 +27,7 @@ fn create_memory_fs() -> InMemoryFS {
                 OsStr::new("README.md"),
                 0o755,
                 0,
-                OpenFlags::empty(),
+                OpenFlags(0),
             )
             .unwrap();
         let _ = memoryfs
@@ -37,8 +37,8 @@ fn create_memory_fs() -> InMemoryFS {
                 fd.borrow(),
                 SeekFrom::Start(0),
                 README_CONTENT.to_vec(),
-                FUSEWriteFlags::empty(),
-                OpenFlags::empty(),
+                WriteFlags::empty(),
+                OpenFlags(0),
                 None,
             )
             .unwrap();

--- a/examples/random_fs/src/main.rs
+++ b/examples/random_fs/src/main.rs
@@ -42,7 +42,7 @@ impl RandomFS {
     }
 
     fn random_inode(rng: &mut ThreadRng) -> Inode {
-        Inode::from(rng.gen::<u64>())
+        INodeNo(rng.gen::<u64>())
     }
 
     fn random_string(rng: &mut ThreadRng, len: usize) -> String {
@@ -67,7 +67,7 @@ impl FuseHandler for RandomFS {
         bmap, copy_file_range, fallocate, flush, fsync, fsyncdir, getlk, getxattr, ioctl, link, listxattr, lseek, mknod, open, opendir, readlink, release, releasedir, removexattr, rename, setlk, setxattr, statfs, symlink
     ] }
 
-    fn access(&self, _req: &RequestInfo, _file_id: Inode, _mask: AccessMask) -> FuseResult<()> {
+    fn access(&self, _req: &RequestInfo, _file_id: Inode, _mask: AccessFlags) -> FuseResult<()> {
         Ok(())
     }
 
@@ -83,7 +83,7 @@ impl FuseHandler for RandomFS {
         (
             OwnedFileHandle,
             (Inode, FileAttribute),
-            FUSEOpenResponseFlags,
+            FopenFlags,
         ),
         PosixError,
     > {
@@ -94,7 +94,7 @@ impl FuseHandler for RandomFS {
             // Safe because we won't release it
             unsafe { OwnedFileHandle::from_raw(0) },
             (ino, attr),
-            FUSEOpenResponseFlags::empty(),
+            FopenFlags::empty(),
         ))
     }
 
@@ -173,7 +173,7 @@ impl FuseHandler for RandomFS {
         _fh: BorrowedFileHandle,
         offset: SeekFrom,
         size: u32,
-        _flags: FUSEOpenFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
         let mut rng = rand::thread_rng();
@@ -238,7 +238,7 @@ impl FuseHandler for RandomFS {
         _fh: BorrowedFileHandle,
         _offset: SeekFrom,
         data: Vec<u8>,
-        _write_flags: FUSEWriteFlags,
+        _write_flags: WriteFlags,
         _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<u32> {

--- a/examples/zip_fs/src/filesystem.rs
+++ b/examples/zip_fs/src/filesystem.rs
@@ -137,7 +137,7 @@ impl FuseHandler for ZipFs {
         _file_handle: BorrowedFileHandle,
         seek: SeekFrom,
         size: u32,
-        _flags: FUSEOpenFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
         let InodeInfo {

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,4 +3,4 @@ pub(crate) mod helpers;
 
 mod inode_mapping;
 
-pub(crate) use inode_mapping::{FileIdResolver, InodeResolvable, ROOT_INO};
+pub(crate) use inode_mapping::{FileIdResolver, InodeResolvable};

--- a/src/core/inode_mapping.rs
+++ b/src/core/inode_mapping.rs
@@ -9,10 +9,9 @@ use std::{
 
 use std::sync::{RwLock, atomic::AtomicU64};
 
+
 use crate::{inode_mapper, types::*};
 use crate::{inode_mapper::InodeMapper, inode_multi_mapper::*};
-
-pub(crate) const ROOT_INO: u64 = 1;
 
 /// Trait to allow a FileIdType to be mapped to use a converter
 pub trait InodeResolvable {
@@ -62,23 +61,23 @@ pub trait FileIdResolver: Send + Sync + 'static {
     type ResolvedType: FileIdType;
 
     fn new() -> Self;
-    fn resolve_id(&self, ino: u64) -> Self::ResolvedType;
+    fn resolve_id(&self, ino: Inode) -> Self::ResolvedType;
     fn lookup(
         &self,
-        parent: u64,
+        parent: Inode,
         child: &OsStr,
         id: <Self::ResolvedType as FileIdType>::_Id,
         increment: bool,
-    ) -> u64;
+    ) -> Inode;
     fn add_children(
         &self,
-        parent: u64,
+        parent: Inode,
         children: Vec<(OsString, <Self::ResolvedType as FileIdType>::_Id)>,
         increment: bool,
-    ) -> Vec<(OsString, u64)>;
-    fn forget(&self, ino: u64, nlookup: u64);
+    ) -> Vec<(OsString, Inode)>;
+    fn forget(&self, ino: Inode, nlookup: u64);
     fn prune(&self, keep: &HashSet<Self::ResolvedType>);
-    fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr);
+    fn rename(&self, parent: Inode, name: &OsStr, newparent: Inode, newname: &OsStr);
 }
 
 pub struct InodeResolver {}
@@ -90,32 +89,28 @@ impl FileIdResolver for InodeResolver {
         Self {}
     }
 
-    fn resolve_id(&self, ino: u64) -> Self::ResolvedType {
-        Inode::from(ino)
+    fn resolve_id(&self, ino: Inode) -> Self::ResolvedType {
+        ino
     }
 
-    fn lookup(&self, _parent: u64, _child: &OsStr, id: Inode, _increment: bool) -> u64 {
-        id.into()
+    fn lookup(&self, _parent: Inode, _child: &OsStr, id: Inode, _increment: bool) -> Inode {
+        id
     }
 
-    // Do nothing, user should provide its own inode
     fn add_children(
         &self,
-        _parent: u64,
+        _parent: Inode,
         children: Vec<(OsString, Inode)>,
         _increment: bool,
-    ) -> Vec<(OsString, u64)> {
+    ) -> Vec<(OsString, Inode)> {
         children
-            .into_iter()
-            .map(|(name, inode)| (name, u64::from(inode)))
-            .collect()
     }
 
-    fn forget(&self, _ino: u64, _nlookup: u64) {}
+    fn forget(&self, _ino: Inode, _nlookup: u64) {}
 
     fn prune(&self, _keep: &HashSet<Self::ResolvedType>) {}
 
-    fn rename(&self, _parent: u64, _name: &OsStr, _newparent: u64, _newname: &OsStr) {}
+    fn rename(&self, _parent: Inode, _name: &OsStr, _newparent: Inode, _newname: &OsStr) {}
 }
 
 pub struct ComponentsResolver {
@@ -131,47 +126,44 @@ impl FileIdResolver for ComponentsResolver {
         }
     }
 
-    fn resolve_id(&self, ino: u64) -> Self::ResolvedType {
+    fn resolve_id(&self, ino: Inode) -> Self::ResolvedType {
         self.mapper
             .read()
             .unwrap()
-            .resolve(&Inode::from(ino))
+            .resolve(&ino)
             .expect("Failed to resolve inode")
             .iter()
             .map(|inode_info| (**inode_info.name).clone())
             .collect()
     }
 
-    fn lookup(&self, parent: u64, child: &OsStr, _id: (), increment: bool) -> u64 {
-        let parent = Inode::from(parent);
+    fn lookup(&self, parent: Inode, child: &OsStr, _id: (), increment: bool) -> Inode {
         {
             // Optimistically assume the child exists
             if let Some(lookup_result) = self.mapper.read().unwrap().lookup(&parent, child) {
                 if increment {
                     lookup_result.data.fetch_add(1, Ordering::SeqCst);
                 }
-                return u64::from(lookup_result.inode.clone());
+                return lookup_result.inode.clone();
             }
         }
         // This scenario happens if the child node does not exist or the backing ID does not match
-        u64::from(
-            self.mapper
-                .write()
-                .expect("Failed to acquire write lock")
-                .insert_child(&parent, child.to_os_string(), |_| {
-                    // If the child node already exists, use the existing reference count
-                    AtomicU64::new(if increment { 1 } else { 0 })
-                })
-                .expect("Failed to insert child"),
-        )
+        self.mapper
+            .write()
+            .expect("Failed to acquire write lock")
+            .insert_child(&parent, child.to_os_string(), |_| {
+                // If the child node already exists, use the existing reference count
+                AtomicU64::new(if increment { 1 } else { 0 })
+            })
+            .expect("Failed to insert child")
     }
 
     fn add_children(
         &self,
-        parent: u64,
+        parent: Inode,
         children: Vec<(OsString, ())>,
         increment: bool,
-    ) -> Vec<(OsString, u64)> {
+    ) -> Vec<(OsString, Inode)> {
         let value_creator = |value_creator: inode_mapper::ValueCreatorParams<AtomicU64>| {
             if let Some(nlookup) = value_creator.existing_data {
                 let count = nlookup.load(Ordering::Relaxed);
@@ -184,31 +176,29 @@ impl FileIdResolver for ComponentsResolver {
             .iter()
             .map(|(name, _)| (name.clone(), value_creator))
             .collect();
-        let parent_inode = Inode::from(parent);
         let inserted_children = self
             .mapper
             .write()
             .expect("Failed to acquire write lock")
-            .insert_children(&parent_inode, children_with_creator)
+            .insert_children(&parent, children_with_creator)
             .expect("Failed to insert children");
         inserted_children
             .into_iter()
             .zip(children)
-            .map(|(inode, (name, _))| (name, u64::from(inode)))
+            .map(|(inode, (name, _))| (name, inode))
             .collect()
     }
 
-    fn forget(&self, ino: u64, nlookup: u64) {
-        let inode = Inode::from(ino);
+    fn forget(&self, ino: Inode, nlookup: u64) {
         {
             // Optimistically assume we don't have to remove yet
             let guard = self.mapper.read().expect("Failed to acquire read lock");
-            let inode_info = guard.get(&inode).expect("Failed to find inode");
+            let inode_info = guard.get(&ino).expect("Failed to find inode");
             if inode_info.data.fetch_sub(nlookup, Ordering::SeqCst) > 0 {
                 return;
             }
         }
-        self.mapper.write().unwrap().remove(&inode).unwrap();
+        self.mapper.write().unwrap().remove(&ino).unwrap();
     }
 
     fn prune(&self, keep: &HashSet<Self::ResolvedType>) {
@@ -218,16 +208,14 @@ impl FileIdResolver for ComponentsResolver {
             .prune(keep);
     }
 
-    fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr) {
-        let parent_inode = Inode::from(parent);
-        let newparent_inode = Inode::from(newparent);
+    fn rename(&self, parent: Inode, name: &OsStr, newparent: Inode, newname: &OsStr) {
         self.mapper
             .write()
             .expect("Failed to acquire write lock")
             .rename(
-                &parent_inode,
+                &parent,
                 name,
-                &newparent_inode,
+                &newparent,
                 newname.to_os_string(),
             )
             .expect("Failed to rename inode");
@@ -247,7 +235,7 @@ impl FileIdResolver for PathResolver {
         }
     }
 
-    fn resolve_id(&self, ino: u64) -> Self::ResolvedType {
+    fn resolve_id(&self, ino: Inode) -> Self::ResolvedType {
         self.resolver
             .resolve_id(ino)
             .iter()
@@ -257,24 +245,24 @@ impl FileIdResolver for PathResolver {
 
     fn lookup(
         &self,
-        parent: u64,
+        parent: Inode,
         child: &OsStr,
         id: <Self::ResolvedType as FileIdType>::_Id,
         increment: bool,
-    ) -> u64 {
+    ) -> Inode {
         self.resolver.lookup(parent, child, id, increment)
     }
 
     fn add_children(
         &self,
-        parent: u64,
+        parent: Inode,
         children: Vec<(OsString, <Self::ResolvedType as FileIdType>::_Id)>,
         increment: bool,
-    ) -> Vec<(OsString, u64)> {
+    ) -> Vec<(OsString, Inode)> {
         self.resolver.add_children(parent, children, increment)
     }
 
-    fn forget(&self, ino: u64, nlookup: u64) {
+    fn forget(&self, ino: Inode, nlookup: u64) {
         self.resolver.forget(ino, nlookup);
     }
 
@@ -286,7 +274,7 @@ impl FileIdResolver for PathResolver {
         self.resolver.prune(&resolver_keep);
     }
 
-    fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr) {
+    fn rename(&self, parent: Inode, name: &OsStr, newparent: Inode, newname: &OsStr) {
         self.resolver.rename(parent, name, newparent, newname);
     }
 }
@@ -309,18 +297,17 @@ where
         HybridResolver { mapper: instance }
     }
 
-    fn resolve_id(&self, ino: u64) -> Self::ResolvedType {
-        HybridId::new(Inode::from(ino), self.mapper.clone())
+    fn resolve_id(&self, ino: Inode) -> Self::ResolvedType {
+        HybridId::new(ino, self.mapper.clone())
     }
 
     fn lookup(
         &self,
-        parent: u64,
+        parent: Inode,
         child: &OsStr,
         id: <Self::ResolvedType as FileIdType>::_Id,
         increment: bool,
-    ) -> u64 {
-        let parent = Inode::from(parent);
+    ) -> Inode {
         {
             // Optimistically assume the child exists
             if let Some(lookup_result) = self
@@ -334,36 +321,34 @@ where
                     if increment {
                         lookup_result.data.fetch_add(1, Ordering::SeqCst);
                     }
-                    return u64::from(lookup_result.inode.clone());
+                    return lookup_result.inode.clone();
                 }
             }
         }
         // This scenario happens if the child node does not exist or the backing ID does not match
-        u64::from(
-            self.mapper
-                .write()
-                .expect("Failed to acquire write lock")
-                .insert_child(&parent, child.to_os_string(), id, |params| {
-                    // If the child node already exists, use the existing reference count
-                    let mut new_value = params
-                        .existing_data
-                        .map(|d| d.load(Ordering::SeqCst))
-                        .unwrap_or(0);
-                    if increment {
-                        new_value += 1;
-                    }
-                    AtomicU64::new(new_value)
-                })
-                .expect("Failed to insert child"),
-        )
+        self.mapper
+            .write()
+            .expect("Failed to acquire write lock")
+            .insert_child(&parent, child.to_os_string(), id, |params| {
+                // If the child node already exists, use the existing reference count
+                let mut new_value = params
+                    .existing_data
+                    .map(|d| d.load(Ordering::SeqCst))
+                    .unwrap_or(0);
+                if increment {
+                    new_value += 1;
+                }
+                AtomicU64::new(new_value)
+            })
+            .expect("Failed to insert child")
     }
 
     fn add_children(
         &self,
-        parent: u64,
+        parent: Inode,
         children: Vec<(OsString, <Self::ResolvedType as FileIdType>::_Id)>,
         increment: bool,
-    ) -> Vec<(OsString, u64)> {
+    ) -> Vec<(OsString, Inode)> {
         let value_creator = |value_creator: ValueCreatorParams<AtomicU64>| {
             if let Some(nlookup) = value_creator.existing_data {
                 let count = nlookup.load(Ordering::Relaxed);
@@ -376,26 +361,24 @@ where
             .iter()
             .map(|(name, id)| (name.clone(), id.clone(), value_creator))
             .collect();
-        let parent_inode = Inode::from(parent);
         let inserted_children = self
             .mapper
             .write()
             .expect("Failed to acquire write lock")
-            .insert_children(&parent_inode, children_with_creator)
+            .insert_children(&parent, children_with_creator)
             .expect("Failed to insert children");
         inserted_children
             .into_iter()
             .zip(children)
-            .map(|(inode, (name, _))| (name, u64::from(inode)))
+            .map(|(inode, (name, _))| (name, inode))
             .collect()
     }
 
-    fn forget(&self, ino: u64, nlookup: u64) {
-        let inode = Inode::from(ino);
+    fn forget(&self, ino: Inode, nlookup: u64) {
         {
             // Optimistically assume we don't have to remove yet
             let guard = self.mapper.read().expect("Failed to acquire read lock");
-            let inode_info = guard.get(&inode).expect("Failed to find inode");
+            let inode_info = guard.get(&ino).expect("Failed to find inode");
             if inode_info.data.fetch_sub(nlookup, Ordering::SeqCst) > 0 {
                 return;
             }
@@ -403,7 +386,7 @@ where
         self.mapper
             .write()
             .expect("Failed to acquire write lock")
-            .remove(&inode)
+            .remove(&ino)
             .unwrap();
     }
 
@@ -411,16 +394,14 @@ where
         // TODO
     }
 
-    fn rename(&self, parent: u64, name: &OsStr, newparent: u64, newname: &OsStr) {
-        let parent_inode = Inode::from(parent);
-        let newparent_inode = Inode::from(newparent);
+    fn rename(&self, parent: Inode, name: &OsStr, newparent: Inode, newname: &OsStr) {
         self.mapper
             .write()
             .expect("Failed to acquire write lock")
             .rename(
-                &parent_inode,
+                &parent,
                 name,
-                &newparent_inode,
+                &newparent,
                 newname.to_os_string(),
             )
             .expect("Failed to rename inode");
@@ -438,7 +419,7 @@ mod tests {
         let resolver = ComponentsResolver::new();
 
         // Test lookup and resolve_id
-        let parent_ino = ROOT_INODE.into();
+        let parent_ino = ROOT_INODE;
         let child_ino = resolver.lookup(parent_ino, OsStr::new("child"), (), true);
         let resolved_path = resolver.resolve_id(child_ino);
 
@@ -470,20 +451,13 @@ mod tests {
         // Test prune
         let keep = HashSet::new();
         resolver.prune(&keep);
-
-        // child_ino should be gone now because refcount was 0 (decremented by earlier forget) and we pruned it.
-        // We can verify it's gone by trying to resolve it and expecting panic (as per other test) or just by knowing prune works.
-        // But calling forget again is definitely wrong if it's gone.
-
-        // If we want to test that prune actually removed it, we should check existence.
-        // But since we can't easily check existence without internal access, we rely on the fact that subsequent operations might fail or the other test.
     }
 
     #[test]
     #[should_panic(expected = "Failed to resolve inode")]
     fn test_components_resolver_prune_panics_on_resolved_deleted() {
         let resolver = ComponentsResolver::new();
-        let parent_ino = ROOT_INO;
+        let parent_ino = ROOT_INODE;
         let child_ino = resolver.lookup(parent_ino, OsStr::new("child"), (), true);
         resolver.forget(child_ino, 1);
         resolver.prune(&HashSet::new());
@@ -495,7 +469,7 @@ mod tests {
         let resolver = PathResolver::new();
 
         // Test lookup and resolve_id for root
-        let root_ino = ROOT_INODE.into();
+        let root_ino = ROOT_INODE;
         let root_path = resolver.resolve_id(root_ino);
         assert_eq!(root_path, PathBuf::from(""));
 
@@ -556,7 +530,7 @@ mod tests {
 
         // Test lookup for non-existent file
         let non_existent_ino = resolver.lookup(root_ino, OsStr::new("non_existent"), (), false);
-        assert_ne!(non_existent_ino, 0);
+        assert_ne!(non_existent_ino.0, 0);
         let non_existent_path = resolver.resolve_id(non_existent_ino);
         assert_eq!(non_existent_path, PathBuf::from("non_existent"));
     }
@@ -566,7 +540,7 @@ mod tests {
         let resolver = HybridResolver::<u64>::new();
 
         // Test lookup and resolve_id for root
-        let root_ino = ROOT_INODE.into();
+        let root_ino = ROOT_INODE;
         let root_id = resolver.resolve_id(root_ino);
         assert_eq!(root_id.first_path(), Some(PathBuf::from("")));
 
@@ -627,7 +601,7 @@ mod tests {
         // Test lookup for non-existent file
         let non_existent_ino =
             resolver.lookup(root_ino, OsStr::new("non_existent"), Some(6), false);
-        assert_ne!(non_existent_ino, 0);
+        assert_ne!(non_existent_ino.0, 0);
         let non_existent_path = resolver.resolve_id(non_existent_ino);
         assert_eq!(
             non_existent_path.first_path(),
@@ -675,7 +649,7 @@ mod tests {
         let resolver = PathResolver::new();
 
         // Test lookup and resolve_id for root
-        let root_ino = ROOT_INODE.into();
+        let root_ino = ROOT_INODE;
         let root_path = resolver.resolve_id(root_ino);
         assert_eq!(root_path, PathBuf::from(""));
 

--- a/src/fuse_presets/default_fuse_handler.rs
+++ b/src/fuse_presets/default_fuse_handler.rs
@@ -84,7 +84,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         }
     }
 
-    pub fn access(&self, _req: &RequestInfo, file_id: TId, mask: AccessMask) -> FuseResult<()> {
+    pub fn access(&self, _req: &RequestInfo, file_id: TId, mask: AccessFlags) -> FuseResult<()> {
         match self.handling {
             HandlingMethod::Error(kind) => Err(PosixError::new(
                 kind,
@@ -131,19 +131,19 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         _req: &RequestInfo,
         file_in: TId,
         file_handle_in: BorrowedFileHandle,
-        offset_in: i64,
+        offset_in: u64,
         file_out: TId,
         file_handle_out: BorrowedFileHandle,
-        offset_out: i64,
+        offset_out: u64,
         len: u64,
-        flags: u32, // Not implemented yet in standard
+        flags: CopyFileRangeFlags,
     ) -> FuseResult<u32> {
         match self.handling {
             HandlingMethod::Error(kind) => Err(PosixError::new(
                 kind,
                 if cfg!(debug_assertions) {
                     format!(
-                        "copy_file_range(file_in: {}, file_handle_in: {:?}, offset_in: {}, file_out: {}, file_handle_out: {:?}, offset_out: {}, len: {}, flags: {})",
+                        "copy_file_range(file_in: {}, file_handle_in: {:?}, offset_in: {}, file_out: {}, file_handle_out: {:?}, offset_out: {}, len: {}, flags: {:?})",
                         file_in.display(),
                         file_handle_in,
                         offset_in,
@@ -158,7 +158,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
                 },
             )),
             HandlingMethod::Panic => panic!(
-                "[Not Implemented] copy_file_range(file_in: {}, file_handle_in: {:?}, offset_in: {}, file_out: {}, file_handle_out: {:?}, offset_out: {}, len: {}, flags: {})",
+                "[Not Implemented] copy_file_range(file_in: {}, file_handle_in: {:?}, offset_in: {}, file_out: {}, file_handle_out: {:?}, offset_out: {}, len: {}, flags: {:?})",
                 file_in.display(),
                 file_handle_in,
                 offset_in,
@@ -179,7 +179,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         mode: u32,
         umask: u32,
         flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, TId::Metadata, FUSEOpenResponseFlags)> {
+    ) -> FuseResult<(OwnedFileHandle, TId::Metadata, FopenFlags)> {
         match self.handling {
             HandlingMethod::Error(kind) => Err(PosixError::new(
                 kind,
@@ -410,7 +410,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         _req: &RequestInfo,
         file_id: TId,
         file_handle: BorrowedFileHandle,
-        flags: IOCtlFlags,
+        flags: IoctlFlags,
         cmd: u32,
         in_data: Vec<u8>,
         out_size: u32,
@@ -619,7 +619,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         _req: &RequestInfo,
         file_id: TId,
         flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)> {
+    ) -> FuseResult<(OwnedFileHandle, FopenFlags)> {
         match self.handling {
             HandlingMethod::Error(kind) => Err(PosixError::new(
                 kind,
@@ -642,11 +642,11 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         _req: &RequestInfo,
         _file_id: TId,
         _flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)> {
+    ) -> FuseResult<(OwnedFileHandle, FopenFlags)> {
         // Safe because in releasedir we don't use it
         Ok((
             unsafe { OwnedFileHandle::from_raw(0) },
-            FUSEOpenResponseFlags::empty(),
+            FopenFlags::empty(),
         ))
     }
 
@@ -657,7 +657,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         file_handle: BorrowedFileHandle,
         seek: SeekFrom,
         size: u32,
-        flags: FUSEOpenFlags,
+        flags: OpenFlags,
         lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>> {
         match self.handling {
@@ -954,7 +954,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         file_id: TId,
         name: &OsStr,
         _value: Vec<u8>,
-        flags: FUSESetXAttrFlags,
+        flags: SetXAttrFlags,
         position: u32,
     ) -> FuseResult<()> {
         match self.handling {
@@ -1045,7 +1045,7 @@ impl<TId: FileIdType> DefaultFuseHandler<TId> {
         file_handle: BorrowedFileHandle,
         seek: SeekFrom,
         data: Vec<u8>,
-        write_flags: FUSEWriteFlags,
+        write_flags: WriteFlags,
         flags: OpenFlags,
         lock_owner: Option<u64>,
     ) -> FuseResult<u32> {

--- a/src/fuse_presets/fd_handler_helper.rs
+++ b/src/fuse_presets/fd_handler_helper.rs
@@ -112,7 +112,7 @@ macro_rules! fd_handler_readonly_methods {
             file_handle: BorrowedFileHandle,
             seek: SeekFrom,
             size: u32,
-            _flags: FUSEOpenFlags,
+            _flags: OpenFlags,
             _lock_owner: Option<u64>,
         ) -> FuseResult<Vec<u8>> {
             unix_fs::read(file_handle.as_borrowed_fd(), seek, size as usize)
@@ -139,18 +139,18 @@ macro_rules! fd_handler_readwrite_methods {
             _req: &RequestInfo,
             _file_in: $file_id,
             file_handle_in: BorrowedFileHandle,
-            offset_in: i64,
+            offset_in: u64,
             _file_out: $file_id,
             file_handle_out: BorrowedFileHandle,
-            offset_out: i64,
+            offset_out: u64,
             len: u64,
-            _flags: u32,
+            _flags: CopyFileRangeFlags,
         ) -> FuseResult<u32> {
             unix_fs::copy_file_range(
                 file_handle_in.as_borrowed_fd(),
-                offset_in,
+                offset_in as i64,
                 file_handle_out.as_borrowed_fd(),
-                offset_out,
+                offset_out as i64,
                 len,
             )
         }
@@ -174,7 +174,7 @@ macro_rules! fd_handler_readwrite_methods {
             file_handle: BorrowedFileHandle,
             seek: SeekFrom,
             data: Vec<u8>,
-            _write_flags: FUSEWriteFlags,
+            _write_flags: WriteFlags,
             _flags: OpenFlags,
             _lock_owner: Option<u64>,
         ) -> FuseResult<u32> {

--- a/src/fuse_presets/mirror_fs.rs
+++ b/src/fuse_presets/mirror_fs.rs
@@ -79,7 +79,7 @@ use crate::unix_fs;
 
 macro_rules! mirror_fs_readonly_methods {
     () => {
-        pub fn access(&self, _req: &RequestInfo, file_id: std::path:: PathBuf, mask: AccessMask) -> FuseResult<()> {
+        pub fn access(&self, _req: &RequestInfo, file_id: std::path:: PathBuf, mask: AccessFlags) -> FuseResult<()> {
             let file_path = self.source_path.join(file_id);
             unix_fs::access(&file_path, mask)
         }
@@ -130,12 +130,12 @@ macro_rules! mirror_fs_readonly_methods {
             _req: &RequestInfo,
             file_id: std::path:: PathBuf,
             flags: OpenFlags,
-        ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)> {
+        ) -> FuseResult<(OwnedFileHandle, FopenFlags)> {
             let file_path = self.source_path.join(file_id);
             let fd = unix_fs::open(file_path.as_ref(), flags)?;
             // Open by definition returns positive Fd or error
             let file_handle = OwnedFileHandle::from_owned_fd(fd).unwrap();
-            Ok((file_handle, FUSEOpenResponseFlags::empty()))
+            Ok((file_handle, FopenFlags::empty()))
         }
 
         pub fn readdir(
@@ -177,12 +177,12 @@ macro_rules! mirror_fs_readwrite_methods {
             mode: u32,
             umask: u32,
             flags: OpenFlags,
-        ) -> FuseResult<(OwnedFileHandle, FileAttribute, FUSEOpenResponseFlags)> {
+        ) -> FuseResult<(OwnedFileHandle, FileAttribute, FopenFlags)> {
             let file_path = self.source_path.join(parent_id).join(name);
             let (fd, file_attr) = unix_fs::create(&file_path, mode, umask, flags)?;
             // Open by definition returns positive Fd or error
             let file_handle = OwnedFileHandle::from_owned_fd(fd).unwrap();
-            Ok((file_handle, file_attr, FUSEOpenResponseFlags::empty()))
+            Ok((file_handle, file_attr, FopenFlags::empty()))
         }
 
         pub fn mkdir(
@@ -255,7 +255,7 @@ macro_rules! mirror_fs_readwrite_methods {
             file_id: std::path:: PathBuf,
             name: &std::ffi::OsStr,
             value: Vec<u8>,
-            flags: FUSESetXAttrFlags,
+            flags: SetXAttrFlags,
             position: u32,
         ) -> FuseResult<()> {
             let file_path = self.source_path.join(file_id);

--- a/src/inode_mapper.rs
+++ b/src/inode_mapper.rs
@@ -4,7 +4,7 @@ use std::ffi::{OsStr, OsString};
 use std::hash::Hash;
 use std::sync::Arc;
 
-use crate::types::{Inode, ROOT_INODE};
+use crate::types::{Inode, ROOT_INODE, InodeExt};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Helper structure for managing inodes and their relationships.
@@ -599,7 +599,7 @@ mod tests {
     use std::collections::HashSet;
     use std::ffi::OsString;
 
-    use crate::types::{Inode, ROOT_INODE};
+    use crate::types::ROOT_INODE;
 
     #[test]
     fn test_insert_child_returns_old_inode() {
@@ -608,7 +608,7 @@ mod tests {
         let child_name = OsString::from("child");
 
         // Insert the first child
-        let first_child_inode = Inode::from(2);
+        let first_child_inode = fuser::INodeNo(2);
         assert_eq!(
             mapper.insert_child(&root, child_name.clone(), |value_creator_params| {
                 assert!(value_creator_params.existing_data.is_none());
@@ -672,7 +672,7 @@ mod tests {
             }
             path.push(OsString::from(format!("file_{}", i)));
             entries.push((path, move |_: ValueCreatorParams<u64>| i));
-            expected_inodes.insert(Inode::from(i + 2)); // Start from 2 to avoid conflict with root_inode
+            expected_inodes.insert(fuser::INodeNo(i + 2)); // Start from 2 to avoid conflict with root_inode
         }
 
         // Perform batch insert
@@ -683,7 +683,7 @@ mod tests {
 
         // Check if all inserted inodes exist
         for i in 2..=(FILE_COUNT as u64 + 1) {
-            let inode = Inode::from(i);
+            let inode = fuser::INodeNo(i);
             assert!(mapper.get(&inode).is_some(), "{:?} should exist", inode);
         }
 
@@ -743,13 +743,13 @@ mod tests {
         assert!(root_path.is_empty());
 
         // Try to resolve a non-existent inode
-        assert!(mapper.resolve(&Inode::from(999)).is_none());
+        assert!(mapper.resolve(&fuser::INodeNo(999)).is_none());
     }
 
     #[test]
     fn test_resolve_invalid_inode() {
         let mapper = InodeMapper::new(0);
-        let invalid_inode = Inode::from(999);
+        let invalid_inode = fuser::INodeNo(999);
 
         // Attempt to resolve an invalid inode
         let result = mapper.resolve(&invalid_inode);
@@ -946,11 +946,11 @@ mod tests {
     #[test]
     fn test_remove_cascading() {
         let mut mapper = InodeMapper::new(());
-        let child1 = Inode::from(2);
-        let child2 = Inode::from(3);
-        let grandchild1 = Inode::from(4);
-        let grandchild2 = Inode::from(5);
-        let great_grandchild = Inode::from(6);
+        let child1 = fuser::INodeNo(2);
+        let child2 = fuser::INodeNo(3);
+        let grandchild1 = fuser::INodeNo(4);
+        let grandchild2 = fuser::INodeNo(5);
+        let great_grandchild = fuser::INodeNo(6);
 
         // Create a deeper nested structure
         mapper

--- a/src/inode_multi_mapper.rs
+++ b/src/inode_multi_mapper.rs
@@ -1,4 +1,4 @@
-use crate::types::{Inode, ROOT_INODE};
+use crate::types::{Inode, ROOT_INODE, InodeExt};
 use bimap::BiHashMap;
 use std::{
     borrow::Borrow,
@@ -258,7 +258,7 @@ where
                 let mut hasher = std::collections::hash_map::DefaultHasher::new();
                 backing_id.hash(&mut hasher);
                 let hash = hasher.finish();
-                let mut preferred_inode = Inode::from(hash);
+                let mut preferred_inode = fuser::INodeNo(hash);
                 loop {
                     if !self.data.inodes.contains_key(&preferred_inode) {
                         break preferred_inode;
@@ -536,7 +536,7 @@ where
     ///
     /// # Behavior
     /// - Returns Err(InsertError::ParentNotFound) if the parent doesn't exist.
-    /// - If successful, returns Ok(Vec<Inode>) with the newly created or existing child inodes.
+    /// - If successful, returns `Ok(Vec<Inode>)` with the newly created or existing child inodes.
     ///
     /// The value_creator function is called with the new inode, parent inode, child name, and
     /// existing data (if any) as arguments.
@@ -959,7 +959,7 @@ mod tests {
     use std::collections::HashSet;
     use std::ffi::OsString;
 
-    use crate::types::{Inode, ROOT_INODE};
+    use crate::types::ROOT_INODE;
 
     #[test]
     fn test_insert_child_returns_old_inode() {
@@ -968,7 +968,7 @@ mod tests {
         let child_name = OsString::from("child");
 
         // Insert the first child
-        let first_child_inode = Inode::from(2);
+        let first_child_inode = fuser::INodeNo(2);
         assert_eq!(
             mapper.insert_child(&root, child_name.clone(), None, |value_creator_params| {
                 assert!(value_creator_params.existing_data.is_none());
@@ -1041,7 +1041,7 @@ mod tests {
             }
             path.push(OsString::from(format!("file_{}", i)));
             entries.push((path, None, move |_: ValueCreatorParams<u64>| i));
-            expected_inodes.insert(Inode::from(i + 2)); // Start from 2 to avoid conflict with root_inode
+            expected_inodes.insert(fuser::INodeNo(i + 2)); // Start from 2 to avoid conflict with root_inode
         }
 
         // Perform batch insert
@@ -1052,7 +1052,7 @@ mod tests {
 
         // Check if all inserted inodes exist
         for i in 2..=(FILE_COUNT as u64 + 1) {
-            let inode = Inode::from(i);
+            let inode = fuser::INodeNo(i);
             assert!(mapper.get(&inode).is_some(), "{:?} should exist", inode);
         }
 
@@ -1143,13 +1143,13 @@ mod tests {
         assert!(root_path.is_empty());
 
         // Try to resolve a non-existent inode
-        assert!(mapper.resolve(&Inode::from(999)).is_none());
+        assert!(mapper.resolve(&fuser::INodeNo(999)).is_none());
     }
 
     #[test]
     fn test_resolve_invalid_inode() {
         let mapper = InodeMultiMapper::<u64, u64>::new(0);
-        let invalid_inode = Inode::from(999);
+        let invalid_inode = fuser::INodeNo(999);
 
         // Attempt to resolve an invalid inode
         let result = mapper.resolve(&invalid_inode);

--- a/src/session.rs
+++ b/src/session.rs
@@ -37,7 +37,7 @@ impl<T: FileIdType> FuseSession<T> {
     /// Join the background session, waiting for the filesystem to unmount.
     ///
     /// This method blocks until the filesystem is unmounted.
-    pub fn join(self) {
+    pub fn join(self) -> std::io::Result<()> {
         self.session.join()
     }
 }

--- a/src/types/arguments.rs
+++ b/src/types/arguments.rs
@@ -18,7 +18,8 @@
 use std::time::{Duration, SystemTime};
 
 use fuser::FileAttr as FuseFileAttr;
-use fuser::{FileType, Request, TimeOrNow};
+pub use fuser::RequestId;
+use fuser::{FileType, Request, TimeOrNow, INodeNo, BsdFileFlags};
 use libc::mode_t;
 
 use super::BorrowedFileHandle;
@@ -159,13 +160,13 @@ impl StatFs {
 /// - `pid`: Process ID of the process that initiated the request
 #[derive(Debug, Clone)]
 pub struct RequestInfo {
-    pub id: u64,
+    pub id: RequestId,
     pub uid: u32,
     pub gid: u32,
     pub pid: u32,
 }
-impl<'a> From<&Request<'a>> for RequestInfo {
-    fn from(req: &Request<'a>) -> Self {
+impl From<&Request> for RequestInfo {
+    fn from(req: &Request) -> Self {
         Self {
             id: req.unique(),
             uid: req.uid(),
@@ -218,7 +219,7 @@ pub struct FileAttribute {
 
 /// `FuseFileAttr`, `Option<ttl>`, `Option<generation>`
 impl FileAttribute {
-    pub(crate) fn to_fuse(self, ino: u64) -> (FuseFileAttr, Option<Duration>, Option<u64>) {
+    pub(crate) fn to_fuse(self, ino: INodeNo) -> (FuseFileAttr, Option<Duration>, Option<u64>) {
         (
             FuseFileAttr {
                 ino,
@@ -270,7 +271,7 @@ pub struct SetAttrRequest<'a> {
     /// Backup time (for macOS)
     pub bkuptime: Option<SystemTime>,
     /// File flags (unused in FUSE)
-    pub flags: Option<()>,
+    pub flags: Option<BsdFileFlags>,
     /// File handle for the file being modified
     pub file_handle: Option<BorrowedFileHandle<'a>>,
 }
@@ -350,7 +351,7 @@ impl<'a> SetAttrRequest<'a> {
     }
 
     /// Unused by FUSE
-    pub fn flags(mut self, flags: ()) -> Self {
+    pub fn flags(mut self, flags: BsdFileFlags) -> Self {
         self.flags = Some(flags);
         self
     }

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -69,8 +69,8 @@ impl PosixError {
         ErrorKind::from(self.code)
     }
 
-    pub fn raw_error(&self) -> i32 {
-        self.code
+    pub fn io_error(&self) -> std::io::Error {
+        std::io::Error::from_raw_os_error(self.code)
     }
 }
 
@@ -378,10 +378,17 @@ impl From<ErrorKind> for i32 {
             ErrorKind::MultihopAttempted => libc::EMULTIHOP,
             ErrorKind::LinkHasBeenSevered => libc::ENOLINK,
             ErrorKind::NoMessage => libc::ENOMSG,
-            ErrorKind::Unknown(code) => code, // Unknown variant retains its i32 value
+            ErrorKind::Unknown(code) => code,
         }
     }
 }
+
+impl From<ErrorKind> for fuser::Errno {
+    fn from(kind: ErrorKind) -> Self {
+        fuser::Errno::from_i32(i32::from(kind))
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/types/file_id_type.rs
+++ b/src/types/file_id_type.rs
@@ -55,7 +55,7 @@ use fuser::FileType as FileKind;
 ///         - When using first_path method, the pre-supplied PathBuf can change over multiple requests to the same inode, so it should not be used as a
 ///         comparison method.
 ///     - Root: Represented by the constant ROOT_INODE with a value of 1 and an empty string.
-///     - Usage: (see https://github.com/Alogani/easy_fuser/pull/77#issuecomment-3830951142)
+///     - Usage: (see <https://github.com/Alogani/easy_fuser/pull/77#issuecomment-3830951142>)
 ///       - If two paths represents hardlinks, the user will return the same inode to the fuse filesystem
 ///       - The user can use the hardlinks of the current filesystem by using `libc::fstat(...).f_fsid` (Persistent) or libc::fstatfs(...).f_dev` (Ephemeral)
 ///       - When a Fuse operation provides an inode, the user can use `BackingId::all_paths()` to retrieve all the paths associated to that inode

--- a/src/types/flags.rs
+++ b/src/types/flags.rs
@@ -1,27 +1,16 @@
 //! Flags used in FUSE (Filesystem in Userspace) operations.
-//!
-//! This module defines various flag sets used throughout FUSE filesystem operations.
-//! These flags provide fine-grained control over file system behavior and operations.
-//!
-//! Note: Not all flags may be applicable or supported by every FUSE implementation.
-//! The documentation and usage of these flags are subject to ongoing refinement and validation.
+
 use bitflags::bitflags;
 
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    /// Flags used to check file accessibility.
-    pub struct AccessMask: i32 {
-        /// Check if the file exists.
-        const EXISTS = libc::F_OK;
-        /// Check if the file is readable.
-        const CAN_READ = libc::R_OK;
-        /// Check if the file is writable.
-        const CAN_WRITE = libc::W_OK;
-        /// Check if the file is executable.
-        const CAN_EXEC = libc::X_OK;
-        const _ = !0;
-    }
-}
+pub use fuser::{
+    AccessFlags,
+    FopenFlags,
+    OpenFlags,
+    RenameFlags,
+    IoctlFlags,
+    WriteFlags,
+    CopyFileRangeFlags,
+};
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -51,7 +40,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEAttrFlags: u32 {
+    pub struct AttrFlags: u32 {
         const SUBMOUNT = 1 << 0;
         const DAX = 1 << 1;
         const _ = !0;
@@ -60,7 +49,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEGetAttrFlags: i32 {
+    pub struct GetAttrFlags: i32 {
         const GETATTR_FH = 1 << 0;
         const _ = !0;
     }
@@ -68,52 +57,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEOpenFlags: i32 {
-        const KILL_SUIDGID = 1 << 0;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    /// Flags used in the response to a FUSE open operation.
-    pub struct FUSEOpenResponseFlags: u32 {
-        /// Bypass page cache for this file.
-        const DIRECT_IO = 1 << 0;
-        /// Keep cached file data after closing.
-        const KEEP_CACHE = 1 << 1;
-        /// The file is not seekable.
-        const NONSEEKABLE = 1 << 2;
-        /// Cache directory contents.
-        const CACHE_DIR = 1 << 3;
-        /// File is a stream (no file position).
-        const STREAM = 1 << 4;
-        /// Don't flush cached data on close.
-        const NOFLUSH = 1 << 5;
-        /// Allow parallel direct writes.
-        const PARALLEL_DIRECT_WRITES = 1 << 6;
-        /// Pass through operations to underlying filesystem.
-        const PASSTHROUGH = 1 << 7;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEIoctlFlags: u32 {
-        const COMPAT = 1 << 0;
-        const UNRESTRICTED = 1 << 1;
-        const RETRY = 1 << 2;
-        const IOCTL_32BIT = 1 << 3;
-        const DIR = 1 << 4;
-        const COMPAT_X32 = 1 << 5;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEReadFlags: i32 {
+    pub struct ReadFlags: i32 {
         const LOCKOWNER = 1 << 0;
         const _ = !0;
     }
@@ -121,7 +65,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEReleaseFlags: i32 {
+    pub struct ReleaseFlags: i32 {
         const FLUSH = 1 << 0;
         const FLOCK_UNLOCK = 1 << 1;
         const _ = !0;
@@ -130,7 +74,7 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEFsyncFlags: u32 {
+    pub struct FsyncFlags: u32 {
         const FDATASYNC = 1 << 0;
         const _ = !0;
     }
@@ -138,26 +82,8 @@ bitflags! {
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSESetXAttrFlags: i32 {
+    pub struct SetXAttrFlags: i32 {
         const ACL_KILL_SGID = 1 << 0;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct FUSEWriteFlags: u32 {
-        const CACHE = 1 << 0;
-        const LOCKOWNER = 1 << 1;
-        const KILL_SUIDGID = 1 << 2;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    pub struct IOCtlFlags: u32 {
-        // Placeholder for future flags
         const _ = !0;
     }
 }
@@ -173,62 +99,6 @@ bitflags! {
         const READ_LOCK = libc::F_RDLCK as i32;
         /// Exclusive or write lock.
         const WRITE_LOCK = libc::F_WRLCK as i32;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    /// Flags used when opening files.
-    pub struct OpenFlags: i32 {
-        /// Open for reading only.
-        const READ_ONLY = libc::O_RDONLY;
-        /// Open for writing only.
-        const WRITE_ONLY = libc::O_WRONLY;
-        /// Open for reading and writing.
-        const READ_WRITE = libc::O_RDWR;
-        /// Create file if it doesn't exist.
-        const CREATE = libc::O_CREAT;
-        /// Fail if file already exists.
-        const CREATE_EXCLUSIVE = libc::O_EXCL;
-        /// Don't assign controlling terminal.
-        const NO_TERMINAL_CONTROL = libc::O_NOCTTY;
-        /// Truncate file to zero length.
-        const TRUNCATE = libc::O_TRUNC;
-        /// Set append mode.
-        const APPEND_MODE = libc::O_APPEND;
-        /// Use non-blocking mode.
-        const NON_BLOCKING_MODE = libc::O_NONBLOCK;
-        /// Synchronize data writes.
-        const SYNC_DATA_ONLY = libc::O_DSYNC;
-        /// Synchronize both data and metadata writes.
-        const SYNC_DATA_AND_METADATA = libc::O_SYNC;
-        /// Synchronize read operations (Linux only).
-        #[cfg(target_os = "linux")]
-        const SYNC_READS_AND_WRITES = libc::O_RSYNC;
-        /// Fail if not a directory.
-        const MUST_BE_DIRECTORY = libc::O_DIRECTORY;
-        /// Do not follow symlinks.
-        const DO_NOT_FOLLOW_SYMLINKS = libc::O_NOFOLLOW;
-        /// Set close-on-exec flag.
-        const CLOSE_ON_EXEC = libc::O_CLOEXEC;
-        /// Create an unnamed temporary file (Linux only).
-        #[cfg(target_os = "linux")]
-        const TEMPORARY_FILE = libc::O_TMPFILE;
-        const _ = !0;
-    }
-}
-
-bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-    /// Flags used in rename operations.
-    pub struct RenameFlags: u32 {
-        /// Atomically exchange the old and new pathnames. (Linux only)
-        #[cfg(target_os = "linux")]
-        const EXCHANGE = libc::RENAME_EXCHANGE;
-        /// Don't overwrite the destination file if it exists. (Linux only)
-        #[cfg(target_os = "linux")]
-        const NOREPLACE = libc::RENAME_NOREPLACE;
         const _ = !0;
     }
 }

--- a/src/types/inode.rs
+++ b/src/types/inode.rs
@@ -1,65 +1,18 @@
 //! Inode number in a FUSE (Filesystem in Userspace) filesystem.
 
-use crate::core::ROOT_INO;
+pub use fuser::INodeNo;
+pub type Inode = fuser::INodeNo;
 
 /// Represents the mountpoint folder in a FuseFilesystem
-/// Its value is 1 and should not be modified.
-pub const ROOT_INODE: Inode = Inode::from(ROOT_INO);
+/// Its value is 1.
+pub const ROOT_INODE: Inode = fuser::INodeNo::ROOT;
 
-/// Represents an inode number in a FUSE (Filesystem in Userspace) filesystem.
-///
-/// `Inode` implements the `FileIdType` trait, which is used as a generic parameter
-/// throughout this crate. This implementation allows `Inode` to be used as a file
-/// identifier in various fuse operations.
-///
-/// For more detailed information about file identification and the `FileIdType` trait,
-/// please refer to the documentation of the `FileIdType` trait.
-///
-/// In FUSE filesystems, inode numbers are unique identifiers for file system objects,
-/// distinct from traditional Unix-style inodes. The user of this library is responsible
-/// for ensuring the uniqueness of these numbers. Inodes are created for each function
-/// that returns an Inode in FuseHandler, and dropped via the forget function of FuseHandler.
-/// The lookup function is a special case that increments an internal count (handled inside
-/// libfuse) and can create a new inode if it doesn't exist.
-///
-/// Note: This concept is separate from the traditional Unix inode, which is a data structure
-/// describing file system objects like files or directories.
-///
-/// This struct is a wrapper around a u64, providing type safety and
-/// semantic meaning to inode numbers in the FUSE filesystem implementation.
-///
-/// For users who prefer not to manage inodes directly, this library also supports
-/// using `PathBuf` as `FileIdType`. This alternative approach allows for file
-/// identification based on paths rather than inode numbers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Inode(u64);
-
-impl Inode {
-    /// Allow const creation of Inode.
-    pub const fn from(value: u64) -> Self {
-        Inode(value)
-    }
-
-    /// Convenience for creating a new Inode
-    pub fn add_one(&self) -> Self {
-        Inode::from(u64::from(self.clone()) + 1)
-    }
+pub trait InodeExt {
+    fn add_one(&self) -> Self;
 }
 
-impl From<Inode> for u64 {
-    // Converts a u64 into an Inode.
-    ///
-    /// This allows for easy creation of Inode instances from raw inode numbers.
-    fn from(value: Inode) -> Self {
-        value.0
-    }
-}
-
-impl From<u64> for Inode {
-    /// Converts a number into an Inode.
-    ///
-    /// This allows for easy creation of Inode instances from raw inode numbers.
-    fn from(value: u64) -> Self {
-        Inode(value)
+impl InodeExt for fuser::INodeNo {
+    fn add_one(&self) -> Self {
+        fuser::INodeNo(self.0 + 1)
     }
 }

--- a/src/unix_fs.rs
+++ b/src/unix_fs.rs
@@ -480,7 +480,7 @@ pub fn rename(oldpath: &Path, newpath: &Path, flags: RenameFlags) -> Result<(), 
 /// Although this function returns a Fd, it is guaranted to be positive and valid.
 pub fn open(path: &Path, flags: OpenFlags) -> Result<OwnedFd, PosixError> {
     let c_path = cstring_from_path(path)?;
-    let fd = unsafe { libc::open(c_path.as_ptr(), flags.bits()) };
+    let fd = unsafe { libc::open(c_path.as_ptr(), flags.0) };
     if fd == -1 {
         return Err(PosixError::last_error(format!(
             "{}: open failed",
@@ -733,7 +733,7 @@ pub fn setxattr(
     path: &Path,
     name: &OsStr,
     value: &[u8],
-    flags: FUSESetXAttrFlags,
+    flags: SetXAttrFlags,
     position: u32,
 ) -> Result<(), PosixError> {
     let c_path = cstring_from_path(path)?;
@@ -900,7 +900,7 @@ pub fn removexattr(path: &Path, name: &OsStr) -> Result<(), PosixError> {
 ///
 /// It verifies whether the calling process can access the file specified by the path
 /// according to the given access mask.
-pub fn access(path: &Path, mask: AccessMask) -> Result<(), PosixError> {
+pub fn access(path: &Path, mask: AccessFlags) -> Result<(), PosixError> {
     let c_path = cstring_from_path(path)?;
     let ret = unsafe { libc::access(c_path.as_ptr(), mask.bits()) };
     if ret == -1 {
@@ -919,7 +919,7 @@ pub fn access(path: &Path, mask: AccessMask) -> Result<(), PosixError> {
 ///
 /// It creates a new file if it doesn't exist, opens it with write access. It returns a file descriptor
 /// which may not necessarily be equivalent to the FUSE file handle, along with its attributes.
-/// An error is returned if the file already exists and the [OpenFlags::CREATE_EXCLUSIVE] flag is set.
+/// An error is returned if the file already exists and the `O_EXCL` flag is set.
 ///
 /// Although this function returns a Fd, it is guaranted to be positive and valid.
 pub fn create(
@@ -929,7 +929,7 @@ pub fn create(
     flags: OpenFlags,
 ) -> Result<(OwnedFd, FileAttribute), PosixError> {
     let c_path = cstring_from_path(path)?;
-    let open_flags = flags.bits();
+    let open_flags = flags.0;
     let final_mode = mode & !umask;
 
     // Ensure the file is opened with write access if not specified
@@ -1076,7 +1076,7 @@ mod tests {
         let tmpfile = NamedTempFile::new().unwrap();
         fs::write(&tmpfile.path(), "blah").unwrap();
         let attr1 = lookup(&tmpfile.path()).unwrap();
-        let fd = open(&tmpfile.path(), OpenFlags::READ_ONLY).unwrap();
+        let fd = open(&tmpfile.path(), OpenFlags(libc::O_RDONLY)).unwrap();
         let attr2 = getattr(fd.as_fd()).unwrap();
         assert!(attr1.size > 0);
         assert_eq!(attr1, attr2);
@@ -1160,7 +1160,7 @@ mod tests {
     fn test_open() {
         let tmpfile = NamedTempFile::new().unwrap();
 
-        let fd = open(&tmpfile.path(), OpenFlags::empty()).unwrap();
+        let fd = open(&tmpfile.path(), OpenFlags(0)).unwrap();
         assert!(fd.as_raw_fd() > 0);
         drop(tmpfile);
     }
@@ -1170,7 +1170,7 @@ mod tests {
         let tmpfile = NamedTempFile::new().unwrap();
         fs::write(&tmpfile.path(), b"Hello, world!").unwrap();
 
-        let fd = open(&tmpfile.path(), OpenFlags::READ_ONLY).unwrap();
+        let fd = open(&tmpfile.path(), OpenFlags(libc::O_RDONLY)).unwrap();
         let result = read(fd.as_fd(), SeekFrom::Current(0), 5).unwrap();
         assert_eq!(result, b"Hello");
 
@@ -1187,7 +1187,7 @@ mod tests {
     #[test]
     fn test_write() {
         let tmpfile = NamedTempFile::new().unwrap();
-        let fd = open(&tmpfile.path(), OpenFlags::READ_WRITE).unwrap();
+        let fd = open(&tmpfile.path(), OpenFlags(libc::O_RDWR)).unwrap();
 
         // Write data to the file
         let bytes_written = write(fd.as_fd(), SeekFrom::Current(0), b"Hello, world!").unwrap();
@@ -1241,7 +1241,7 @@ mod tests {
             file.write_all(b"Hello, World!").unwrap();
         }
 
-        let fd = open(&path, OpenFlags::READ_WRITE).unwrap();
+        let fd = open(&path, OpenFlags(libc::O_RDWR)).unwrap();
         let borrowed_fd = fd.as_fd();
 
         // Test SeekFrom::Start

--- a/src/unix_fs/linux_fs.rs
+++ b/src/unix_fs/linux_fs.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::types::PosixError;
-use libc::{self, c_char, c_int, c_uint, c_void, off_t, size_t, ssize_t};
+use libc::{self, c_char, c_int, c_uint, c_void, size_t, ssize_t};
 
 use super::{StatFs, cstring_from_path};
 

--- a/templates/fuse_driver.rs.j2
+++ b/templates/fuse_driver.rs.j2
@@ -8,11 +8,11 @@ use std::{
     time::SystemTime,
 };
 
-use libc::c_int;
-use log::{error, info, warn};
+use log::{info, warn};
 
 use fuser::{
-    self, KernelConfig, ReplyAttr, ReplyBmap, ReplyCreate, ReplyData, ReplyDirectory,
+    self, KernelConfig, INodeNo, FileHandle, LockOwner, BsdFileFlags, CopyFileRangeFlags,
+    ReplyAttr, ReplyBmap, ReplyCreate, ReplyData, ReplyDirectory,
     ReplyDirectoryPlus, ReplyEmpty, ReplyEntry, ReplyIoctl, ReplyLock, ReplyLseek, ReplyOpen,
     ReplyStatfs, ReplyWrite, ReplyXattr, Request, TimeOrNow,
 };
@@ -23,7 +23,7 @@ use crate::core::FileIdResolver;
 
 use super::fuse_handler::FuseHandler;
 
-type DirIter<TAttr> = HashMap<(u64, i64), VecDeque<(OsString, u64, TAttr)>>;
+type DirIter<TAttr> = HashMap<(INodeNo, u64), VecDeque<(OsString, INodeNo, TAttr)>>;
 {% macro borrow_mut() -%}
     {% if mode == "serial" %}
         borrow_mut()
@@ -193,6 +193,20 @@ where
 
 
 
+{% if mode == "serial" %}
+unsafe impl<TId, THandler> Send for FuseDriver<TId, THandler>
+where
+    TId: FileIdType,
+    THandler: FuseHandler<TId = TId>,
+{}
+
+unsafe impl<TId, THandler> Sync for FuseDriver<TId, THandler>
+where
+    TId: FileIdType,
+    THandler: FuseHandler<TId = TId>,
+{}
+{% endif %}
+
 impl<TId, THandler> fuser::Filesystem for FuseDriver<TId, THandler>
 where
     TId: FileIdType,
@@ -230,7 +244,7 @@ where
 
     {% macro reply_error() -%}
         {% call spawn_reply() %}
-            reply.error(e.raw_error());
+            reply.error(e.io_error().into());
         {% endcall %}
     {%- endmacro %}
 
@@ -244,7 +258,7 @@ where
                 reply.entry(
                     &ttl.unwrap_or(default_ttl),
                     &fuse_attr,
-                    generation.unwrap_or(get_random_generation()),
+                    fuser::Generation(generation.unwrap_or(get_random_generation())),
                 );
             {% endcall %}
         }
@@ -261,13 +275,13 @@ where
     {%- endmacro %}
 
 
-    fn init(&mut self, req: &Request, config: &mut KernelConfig) -> Result<(), c_int> {
+    fn init(&mut self, req: &Request, config: &mut KernelConfig) -> Result<(), std::io::Error> {
         let req = RequestInfo::from(req);
         match self.get_handler().init(&req, config) {
             Ok(()) => Ok(()),
             Err(e) => {
                 warn!("[{}] init {:?}", e, req);
-                Err(e.raw_error())
+                Err(e.io_error())
             }
         }
     }
@@ -276,7 +290,7 @@ where
         self.get_handler().destroy();
     }
 
-    fn access(&mut self, req: &Request, ino: u64, mask: i32, reply: ReplyEmpty) {
+    fn access(&self, req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -284,7 +298,7 @@ where
             match handler.access(
                 &req,
                 resolver.resolve_id(ino),
-                AccessMask::from_bits_retain(mask),
+                mask,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %}reply.ok();{% endcall %} }
                 Err(e) => {
@@ -296,7 +310,7 @@ where
         {% endcall %}
     }
 
-    fn bmap(&mut self, req: &Request<'_>, ino: u64, blocksize: u32, idx: u64, reply: ReplyBmap) {
+    fn bmap(&self, req: &Request, ino: INodeNo, blocksize: u32, idx: u64, reply: ReplyBmap) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -317,16 +331,16 @@ where
     }
 
     fn copy_file_range(
-        &mut self,
+        &self,
         req: &Request,
-        ino_in: u64,
-        fh_in: u64,
-        offset_in: i64,
-        ino_out: u64,
-        fh_out: u64,
-        offset_out: i64,
+        ino_in: INodeNo,
+        fh_in: FileHandle,
+        offset_in: u64,
+        ino_out: INodeNo,
+        fh_out: FileHandle,
+        offset_out: u64,
         len: u64,
-        flags: u32,
+        flags: CopyFileRangeFlags,
         reply: ReplyWrite,
     ) {
         let req = RequestInfo::from(req);
@@ -336,10 +350,10 @@ where
             match handler.copy_file_range(
                 &req,
                 resolver.resolve_id(ino_in),
-                unsafe { BorrowedFileHandle::from_raw(fh_in) },
+                unsafe { BorrowedFileHandle::from_raw(fh_in.0) },
                 offset_in,
                 resolver.resolve_id(ino_out),
-                unsafe { BorrowedFileHandle::from_raw(fh_out) },
+                unsafe { BorrowedFileHandle::from_raw(fh_out.0) },
                 offset_out,
                 len,
                 flags,
@@ -354,9 +368,9 @@ where
     }
 
     fn create(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
@@ -374,7 +388,7 @@ where
                 &name,
                 mode,
                 umask,
-                OpenFlags::from_bits_retain(flags),
+                OpenFlags(flags),
             ){% if mode == "async" %}.await{% endif %} {
                 Ok((file_handle, metadata, response_flags)) => {
                     let default_ttl = handler.get_default_ttl();
@@ -385,9 +399,9 @@ where
                         reply.created(
                             &ttl.unwrap_or(default_ttl),
                             &fuse_attr,
-                            generation.unwrap_or(get_random_generation()),
-                            file_handle.as_raw(),
-                            response_flags.bits(),
+                            fuser::Generation(generation.unwrap_or(get_random_generation())),
+                            fuser::FileHandle(file_handle.as_raw()),
+                            response_flags,
                         );
                     {% endcall %}
                 }
@@ -400,12 +414,12 @@ where
     }
 
     fn fallocate(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        offset: i64,
-        length: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
+        length: u64,
         mode: i32,
         reply: ReplyEmpty,
     ) {
@@ -416,9 +430,9 @@ where
             match handler.fallocate(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                offset,
-                length,
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                offset as i64,
+                length as i64,
                 FallocateFlags::from_bits_retain(mode),
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
@@ -430,7 +444,7 @@ where
         {% endcall %}
     }
 
-    fn flush(&mut self, req: &Request, ino: u64, fh: u64, lock_owner: u64, reply: ReplyEmpty) {
+    fn flush(&self, req: &Request, ino: INodeNo, fh: FileHandle, lock_owner: LockOwner, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -438,8 +452,8 @@ where
             match handler.flush(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                lock_owner,
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                lock_owner.0,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
                 Err(e) => {
@@ -450,7 +464,7 @@ where
         {% endcall %}
     }
 
-    fn forget(&mut self, req: &Request, ino: u64, nlookup: u64) {
+    fn forget(&self, req: &Request, ino: INodeNo, nlookup: u64) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -462,7 +476,7 @@ where
         {% endcall %}
     }
 
-    fn fsync(&mut self, req: &Request, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+    fn fsync(&self, req: &Request, ino: INodeNo, fh: FileHandle, datasync: bool, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -470,7 +484,7 @@ where
             match handler.fsync(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
                 datasync,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
@@ -482,7 +496,7 @@ where
         {% endcall %}
     }
 
-    fn fsyncdir(&mut self, req: &Request, ino: u64, fh: u64, datasync: bool, reply: ReplyEmpty) {
+    fn fsyncdir(&self, req: &Request, ino: INodeNo, fh: FileHandle, datasync: bool, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -490,7 +504,7 @@ where
             match handler.fsyncdir(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
                 datasync,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
@@ -502,7 +516,7 @@ where
         {% endcall %}
     }
 
-    fn getattr(&mut self, req: &Request, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&self, req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -510,7 +524,7 @@ where
             match handler.getattr(
                 &req,
                 resolver.resolve_id(ino),
-                fh.map(|fh| unsafe { BorrowedFileHandle::from_raw(fh) })
+                fh.map(|fh| unsafe { BorrowedFileHandle::from_raw(fh.0) })
             ){% if mode == "async" %}.await{% endif %} {
                 {{ reply_attr() }}
                 Err(e) => {
@@ -522,11 +536,11 @@ where
     }
 
     fn getlk(
-        &mut self,
-        req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        lock_owner: u64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        lock_owner: LockOwner,
         start: u64,
         end: u64,
         typ: i32,
@@ -546,8 +560,8 @@ where
             match handler.getlk(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                lock_owner,
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                lock_owner.0,
                 lock_info,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(lock_info) => { {% call spawn_reply() %}
@@ -566,7 +580,7 @@ where
         {% endcall %}
     }
 
-    fn getxattr(&mut self, req: &Request, ino: u64, name: &OsStr, size: u32, reply: ReplyXattr) {
+    fn getxattr(&self, req: &Request, ino: INodeNo, name: &OsStr, size: u32, reply: ReplyXattr) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -595,11 +609,11 @@ where
     }
 
     fn ioctl(
-        &mut self,
-        req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        flags: u32,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        flags: IoctlFlags,
         cmd: u32,
         in_data: &[u8],
         out_size: u32,
@@ -613,8 +627,8 @@ where
             match handler.ioctl(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                IOCtlFlags::from_bits_retain(flags),
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                flags,
                 cmd,
                 in_data,
                 out_size,
@@ -629,10 +643,10 @@ where
     }
 
     fn link(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        newparent: u64,
+        ino: INodeNo,
+        newparent: INodeNo,
         newname: &OsStr,
         reply: ReplyEntry,
     ) {
@@ -656,7 +670,7 @@ where
         {% endcall %}
     }
 
-    fn listxattr(&mut self, req: &Request, ino: u64, size: u32, reply: ReplyXattr) {
+    fn listxattr(&self, req: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -683,7 +697,7 @@ where
         {% endcall %}
     }
 
-    fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -705,10 +719,10 @@ where
     }
 
     fn lseek(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
+        ino: INodeNo,
+        fh: FileHandle,
         offset: i64,
         whence: i32,
         reply: ReplyLseek,
@@ -720,7 +734,7 @@ where
             match handler.lseek(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
                 seek_from_raw(Some(whence), offset),
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(new_offset) => { {% call spawn_reply() %} reply.offset(new_offset); {% endcall %} }
@@ -733,9 +747,9 @@ where
     }
 
     fn mkdir(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
@@ -763,9 +777,9 @@ where
     }
 
     fn mknod(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
@@ -794,7 +808,7 @@ where
         {% endcall %}
     }
 
-    fn open(&mut self, req: &Request, ino: u64, _flags: i32, reply: ReplyOpen) {
+    fn open(&self, req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -802,10 +816,10 @@ where
             match handler.open(
                 &req,
                 resolver.resolve_id(ino),
-                OpenFlags::from_bits_retain(_flags),
+                _flags,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok((file_handle, response_flags)) => { {% call spawn_reply() %}
-                    reply.opened(file_handle.as_raw(), response_flags.bits())
+                    reply.opened(fuser::FileHandle(file_handle.as_raw()), response_flags)
                 {% endcall %} }
                 Err(e) => {
                     warn!("open: ino {:x?}, [{}], {:?}", ino, e, req);
@@ -815,7 +829,7 @@ where
         {% endcall %}
     }
 
-    fn opendir(&mut self, req: &Request, ino: u64, _flags: i32, reply: ReplyOpen) {
+    fn opendir(&self, req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -823,10 +837,10 @@ where
             match handler.opendir(
                 &req,
                 resolver.resolve_id(ino),
-                OpenFlags::from_bits_retain(_flags),
+                _flags,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok((file_handle, response_flags)) => { {% call spawn_reply() %}
-                    reply.opened(file_handle.as_raw(), response_flags.bits())
+                    reply.opened(fuser::FileHandle(file_handle.as_raw()), response_flags)
                 {% endcall %} }
                 Err(e) => {
                     warn!("opendir: ino {:x?}, [{}], {:?}", ino, e, req);
@@ -837,14 +851,14 @@ where
     }
 
     fn read(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         size: u32,
-        flags: i32,
-        lock_owner: Option<u64>,
+        flags: OpenFlags,
+        lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
         let req = RequestInfo::from(req);
@@ -854,11 +868,11 @@ where
             match handler.read(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                seek_from_raw(None, offset),
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                std::io::SeekFrom::Start(offset),
                 size,
-                FUSEOpenFlags::from_bits_retain(flags),
-                lock_owner,
+                flags,
+                lock_owner.map(|lo| lo.0),
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(data_reply) => { {% call spawn_reply() %} reply.data(&data_reply); {% endcall %} }
                 Err(e) => {
@@ -878,15 +892,6 @@ where
             self.get_dirmap_iter(){% endif %};
 
         {% call spawn() %}
-            // Validate offset
-            if offset < 0 {
-                error!("readdir called with a negative offset");
-                {% call spawn_reply() %}
-                    reply.error(ErrorKind::InvalidArgument.into());
-                {% endcall %}
-                return;
-            }
-
             // ### Initialize directory iterator
             let mut dir_iter = match offset {
                 // First read: fetch children from handler
@@ -896,7 +901,7 @@ where
                 (
                     &req_info,
                     resolver.resolve_id(ino),
-                    unsafe {BorrowedFileHandle::from_raw(fh)}
+                    unsafe {BorrowedFileHandle::from_raw(fh.0)}
                 ){% if mode == "async" %}.await{% endif %} {
                     Ok(children) => {
                         // Unpack and process children
@@ -960,12 +965,14 @@ where
                             &name,
                             &ttl.unwrap_or(default_ttl),
                             &fuse_attr,
-                            generation.unwrap_or(get_random_generation()),
+                            fuser::Generation(generation.unwrap_or(get_random_generation())),
                         ) {
                             dir_iter.push_front((name, ino, file_attr.clone()));
-                            dirmap_iter
-                                .{{ borrow_mut() }}
-                                .insert((ino, new_offset - 1), dir_iter);
+                            if new_offset > 0 {
+                                dirmap_iter
+                                    .{{ borrow_mut() }}
+                                    .insert((ino, new_offset - 1), dir_iter);
+                            }
                             break;
                         }
                         new_offset += 1;
@@ -976,9 +983,11 @@ where
                     while let Some((name, ino, kind)) = dir_iter.pop_front() {
                         if reply.add(ino, new_offset, kind, &name) {
                             dir_iter.push_front((name, ino, kind));
-                            dirmap_iter
-                                .{{ borrow_mut() }}
-                                .insert((ino, new_offset - 1), dir_iter);
+                            if new_offset > 0 {
+                                dirmap_iter
+                                    .{{ borrow_mut() }}
+                                    .insert((ino, new_offset - 1), dir_iter);
+                            }
                             break;
                         }
                         new_offset += 1;
@@ -990,28 +999,28 @@ where
     {%- endmacro %}
 
     fn readdir(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         mut reply: ReplyDirectory,
     ) {
         {{ readdir_impl(false) }}
     }
 
     fn readdirplus(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         mut reply: ReplyDirectoryPlus,
     ) {
         {{ readdir_impl(true) }}
     }
 
-    fn readlink(&mut self, req: &Request, ino: u64, reply: ReplyData) {
+    fn readlink(&self, req: &Request, ino: INodeNo, reply: ReplyData) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -1030,12 +1039,12 @@ where
     }
 
     fn release(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        ino: INodeNo,
+        fh: FileHandle,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
     ) {
@@ -1046,9 +1055,9 @@ where
             match handler.release(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { OwnedFileHandle::from_raw(fh) },
-                OpenFlags::from_bits_retain(_flags),
-                _lock_owner,
+                unsafe { OwnedFileHandle::from_raw(fh.0) },
+                _flags,
+                _lock_owner.map(|lo| lo.0),
                 _flush,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
@@ -1060,7 +1069,7 @@ where
         {% endcall %}
     }
 
-    fn releasedir(&mut self, req: &Request, ino: u64, fh: u64, flags: i32, reply: ReplyEmpty) {
+    fn releasedir(&self, req: &Request, ino: INodeNo, fh: FileHandle, flags: OpenFlags, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -1068,8 +1077,8 @@ where
             match handler.releasedir(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { OwnedFileHandle::from_raw(fh) },
-                OpenFlags::from_bits_retain(flags),
+                unsafe { OwnedFileHandle::from_raw(fh.0) },
+                flags,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
                 Err(e) => {
@@ -1080,7 +1089,7 @@ where
         {% endcall %}
     }
 
-    fn removexattr(&mut self, req: &Request, ino: u64, name: &OsStr, reply: ReplyEmpty) {
+    fn removexattr(&self, req: &Request, ino: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -1101,13 +1110,13 @@ where
     }
 
     fn rename(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
-        newparent: u64,
+        newparent: INodeNo,
         newname: &OsStr,
-        flags: u32,
+        flags: RenameFlags,
         reply: ReplyEmpty,
     ) {
         let req = RequestInfo::from(req);
@@ -1122,7 +1131,7 @@ where
                 &name,
                 resolver.resolve_id(newparent),
                 &newname,
-                RenameFlags::from_bits_retain(flags),
+                flags,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => {
                     resolver.rename(parent, &name, newparent, &newname);
@@ -1135,7 +1144,7 @@ where
         {% endcall %}
     }
 
-    fn rmdir(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    fn rmdir(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -1156,9 +1165,9 @@ where
     }
 
     fn setattr(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
+        ino: INodeNo,
         mode: Option<u32>,
         uid: Option<u32>,
         gid: Option<u32>,
@@ -1166,11 +1175,11 @@ where
         atime: Option<TimeOrNow>,
         mtime: Option<TimeOrNow>,
         ctime: Option<SystemTime>,
-        fh: Option<u64>,
+        fh: Option<FileHandle>,
         crtime: Option<SystemTime>,
         chgtime: Option<SystemTime>,
         bkuptime: Option<SystemTime>,
-        _flags: Option<u32>,
+        flags: Option<BsdFileFlags>,
         reply: ReplyAttr,
     ) {
         let req = RequestInfo::from(req);
@@ -1187,8 +1196,8 @@ where
             crtime,
             chgtime,
             bkuptime,
-            flags: None,
-            file_handle: fh.map(|fh| unsafe { BorrowedFileHandle::from_raw(fh) }),
+            flags,
+            file_handle: fh.map(|fh| unsafe { BorrowedFileHandle::from_raw(fh.0) }),
         };
         {% call spawn() %}
             match handler.setattr(
@@ -1206,11 +1215,11 @@ where
     }
 
     fn setlk(
-        &mut self,
-        req: &Request<'_>,
-        ino: u64,
-        fh: u64,
-        lock_owner: u64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        lock_owner: LockOwner,
         start: u64,
         end: u64,
         typ: i32,
@@ -1231,8 +1240,8 @@ where
             match handler.setlk(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                lock_owner,
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                lock_owner.0,
                 lock_info,
                 sleep,
             ){% if mode == "async" %}.await{% endif %} {
@@ -1246,9 +1255,9 @@ where
     }
 
     fn setxattr(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
+        ino: INodeNo,
         name: &OsStr,
         value: &[u8],
         flags: i32,
@@ -1266,7 +1275,7 @@ where
                 resolver.resolve_id(ino),
                 &name,
                 value,
-                FUSESetXAttrFlags::from_bits_retain(flags),
+                SetXAttrFlags::from_bits_retain(flags),
                 position,
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(()) => { {% call spawn_reply() %} reply.ok(); {% endcall %} }
@@ -1278,7 +1287,7 @@ where
         {% endcall %}
     }
 
-    fn statfs(&mut self, req: &Request, ino: u64, reply: ReplyStatfs) {
+    fn statfs(&self, req: &Request, ino: INodeNo, reply: ReplyStatfs) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();
@@ -1308,9 +1317,9 @@ where
     }
 
     fn symlink(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         link_name: &OsStr,
         target: &Path,
         reply: ReplyEntry,
@@ -1337,15 +1346,15 @@ where
     }
 
     fn write(
-        &mut self,
+        &self,
         req: &Request,
-        ino: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         data: &[u8],
-        write_flags: u32,
-        flags: i32,
-        lock_owner: Option<u64>,
+        write_flags: WriteFlags,
+        flags: OpenFlags,
+        lock_owner: Option<LockOwner>,
         reply: ReplyWrite,
     ) {
         let req = RequestInfo::from(req);
@@ -1356,12 +1365,12 @@ where
             match handler.write(
                 &req,
                 resolver.resolve_id(ino),
-                unsafe { BorrowedFileHandle::from_raw(fh) },
-                seek_from_raw(None, offset),
+                unsafe { BorrowedFileHandle::from_raw(fh.0) },
+                std::io::SeekFrom::Start(offset),
                 data,
-                FUSEWriteFlags::from_bits_retain(write_flags),
-                OpenFlags::from_bits_retain(flags),
-                lock_owner,
+                write_flags,
+                flags,
+                lock_owner.map(|lo| lo.0),
             ){% if mode == "async" %}.await{% endif %} {
                 Ok(bytes_written) => { {% call spawn_reply() %} reply.written(bytes_written); {% endcall %} }
                 Err(e) => {
@@ -1372,7 +1381,7 @@ where
         {% endcall %}
     }
 
-    fn unlink(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
+    fn unlink(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         let req = RequestInfo::from(req);
         let handler = self.get_handler();
         let resolver = self.resolver.clone();

--- a/templates/fuse_handler.rs.j2
+++ b/templates/fuse_handler.rs.j2
@@ -28,13 +28,8 @@ use async_trait::async_trait;
 /// ```rust,ignore
 /// use easy_fuser::fuse_presets::mirror_fs::*;
 /// use easy_fuser::fuse_presets::DefaultFuseHandler;
-/// {% if mode == "async" -%}
-/// use easy_fuser::fuse_async::prelude::*;
-/// use easy_fuser_macro::delegate_fs_sync_to_async;
-/// {% else -%}
-/// use easy_fuser::fuse_parallel::prelude::*; // or fuse_serial::prelude::*
-/// use easy_fuser_macro::delegate_fs;
-/// {% endif -%}
+/// use easy_fuser::fuse_parallel::prelude::*; // or fuse_serial::prelude::* or fuse_async::prelude::*
+/// use easy_fuser_macro::delegate_fs; // or delegate_fs_sync_to_async for async mode
 /// use std::path::PathBuf;
 /// use std::ffi::OsStr;
 ///
@@ -43,23 +38,6 @@ use async_trait::async_trait;
 ///     default_fs: DefaultFuseHandler<PathBuf>,
 /// }
 ///
-/// {% if mode == "async" -%}
-/// #[async_trait]
-/// impl FuseHandler for MyCustomFs {
-///     type TId = PathBuf;
-///
-///     // Custom implementation for lookup:
-///     async fn lookup(&self, req: &RequestInfo, parent_id: PathBuf, name: &OsStr) -> FuseResult<FileAttribute> {
-///         // Custom logic for lookup operation...
-///         // Delegate to mirror_fs:
-///         self.mirror_fs.lookup(req, parent_id, name)
-///     }
-///
-///     // Delegate other methods:
-///     delegate_fs_sync_to_async! { mirror_fs, [ read, write, getattr ] }
-///     delegate_fs_sync_to_async! { default_fs, [ statfs, link ] }
-/// }
-/// {% else -%}
 /// impl FuseHandler for MyCustomFs {
 ///     type TId = PathBuf;
 ///
@@ -74,7 +52,6 @@ use async_trait::async_trait;
 ///     delegate_fs! { mirror_fs, [ read, write, getattr ] }
 ///     delegate_fs! { default_fs, [ statfs, link ] }
 /// }
-/// {% endif -%}
 /// ```
 ///
 /// # Important Methods
@@ -110,7 +87,7 @@ use async_trait::async_trait;
 /// This behaviour is not well documented and cannot be guaranteed for now.
 ///
 /// # Additional Resources:
-/// For more detailed information, refer to the fuser project documentation, which serves as the foundation for this crate: https://docs.rs/fuser
+/// For more detailed information, refer to the fuser project documentation, which serves as the foundation for this crate: <https://docs.rs/fuser>
 ///
 /// Documentation is inspired by the original fuser documentation
 {%- if mode == "async" %}
@@ -154,7 +131,7 @@ pub trait FuseHandler: 'static
     /// This method is called for the access() system call. If the 'default_permissions'
     /// mount option is given, this method is not called. This method is not called
     /// under Linux kernel versions 2.4.x
-    {{ async_keyword() }} fn access(&self, req: &RequestInfo, file_id: Self::TId, mask: AccessMask) -> FuseResult<()>;
+    {{ async_keyword() }} fn access(&self, req: &RequestInfo, file_id: Self::TId, mask: AccessFlags) -> FuseResult<()>;
 
     /// Map block index within file to block index within device
     ///
@@ -168,12 +145,12 @@ pub trait FuseHandler: 'static
         req: &RequestInfo,
         file_in: Self::TId,
         file_handle_in: BorrowedFileHandle<'_>,
-        offset_in: i64,
+        offset_in: u64,
         file_out: Self::TId,
         file_handle_out: BorrowedFileHandle<'_>,
-        offset_out: i64,
+        offset_out: u64,
         len: u64,
-        flags: u32, // Not implemented yet in standard
+        flags: CopyFileRangeFlags,
     ) -> FuseResult<u32>;
 
     /// Create and open a file
@@ -190,7 +167,7 @@ pub trait FuseHandler: 'static
         mode: u32,
         umask: u32,
         flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, <Self::TId as FileIdType>::Metadata, FUSEOpenResponseFlags)>;
+    ) -> FuseResult<(OwnedFileHandle, <Self::TId as FileIdType>::Metadata, FopenFlags)>;
 
     /// Preallocate or deallocate space to a file
     {{ async_keyword() }} fn fallocate(
@@ -279,7 +256,7 @@ pub trait FuseHandler: 'static
         req: &RequestInfo,
         file_id: Self::TId,
         file_handle: BorrowedFileHandle<'_>,
-        flags: IOCtlFlags,
+        flags: IoctlFlags,
         cmd: u32,
         in_data: Vec<u8>,
         out_size: u32,
@@ -338,7 +315,7 @@ pub trait FuseHandler: 'static
         req: &RequestInfo,
         file_id: Self::TId,
         flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)>;
+    ) -> FuseResult<(OwnedFileHandle, FopenFlags)>;
 
     /// Open a directory
     ///
@@ -348,7 +325,7 @@ pub trait FuseHandler: 'static
         req: &RequestInfo,
         file_id: Self::TId,
         flags: OpenFlags,
-    ) -> FuseResult<(OwnedFileHandle, FUSEOpenResponseFlags)>;
+    ) -> FuseResult<(OwnedFileHandle, FopenFlags)>;
 
     /// Read data from a file
     ///
@@ -362,7 +339,7 @@ pub trait FuseHandler: 'static
         file_handle: BorrowedFileHandle<'_>,
         seek: SeekFrom,
         size: u32,
-        flags: FUSEOpenFlags,
+        flags: OpenFlags,
         lock_owner: Option<u64>,
     ) -> FuseResult<Vec<u8>>;
 
@@ -479,7 +456,7 @@ pub trait FuseHandler: 'static
         file_id: Self::TId,
         name: &OsStr,
         value: Vec<u8>,
-        flags: FUSESetXAttrFlags,
+        flags: SetXAttrFlags,
         position: u32,
     ) -> FuseResult<()>;
 
@@ -507,7 +484,7 @@ pub trait FuseHandler: 'static
         file_handle: BorrowedFileHandle<'_>,
         seek: SeekFrom,
         data: Vec<u8>,
-        write_flags: FUSEWriteFlags,
+        write_flags: WriteFlags,
         flags: OpenFlags,
         lock_owner: Option<u64>,
     ) -> FuseResult<u32>;

--- a/templates/mounting.rs.j2
+++ b/templates/mounting.rs.j2
@@ -1,8 +1,7 @@
 use std::io;
 use std::path::Path;
 
-use fuser::{mount2, spawn_mount2};
-use fuser::MountOption;
+use fuser::{mount2, spawn_mount2, Config, MountOption};
 
 use crate::types::*;
 use crate::FuseSession;
@@ -46,7 +45,10 @@ where
         filesystem,
         num_threads,
         );
-    mount2(driver, mountpoint, options)
+    let mut config = Config::default();
+    config.mount_options = options.to_vec();
+    config.n_threads = num_threads;
+    mount2(driver, mountpoint, &config)
 }
 
 /// Spawns a FUSE filesystem in the background at the specified mountpoint.
@@ -96,6 +98,9 @@ where
         num_threads,
         );
     let resolver = driver.resolver.clone();
-    let session = spawn_mount2(driver, mountpoint, options)?;
+    let mut config = Config::default();
+    config.mount_options = options.to_vec();
+    config.n_threads = num_threads;
+    let session = spawn_mount2(driver, mountpoint, &config)?;
     Ok(FuseSession::new(session, resolver))
 }


### PR DESCRIPTION
Types defined in fuser crates are replacing the ones in easy_fuser no longer needed :
- Mask / Flags mainly
- Inode, replaced by INodeNo
- and internally u64 representing raw inode in inode_mapper (also replaced by INodeNo)