### PR TITLE
fix ttl_generation

### DIFF
--- a/src/core/helpers.rs
+++ b/src/core/helpers.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 #[cfg(feature = "deadlock_detection")]
 pub(crate) fn spawn_deadlock_checker() {
     use log::{error, info};
@@ -28,6 +26,15 @@ pub(crate) fn spawn_deadlock_checker() {
     });
 }
 
-pub(crate) fn get_random_generation() -> u64 {
-    Instant::now().elapsed().as_nanos() as u64
+/// Returns the default generation number for FUSE replies.
+///
+/// We return 0 by default to avoid invalidating kernel dentries during lookup
+/// re-validation. Returning a different/random generation number on every lookup
+/// would cause the kernel to think the inode was replaced.
+///
+/// NOTE: Unique generation numbers are only required if exporting the FUSE filesystem
+/// over NFS. For NFS support, filesystems should explicitly track generation numbers
+/// and populate the `generation` field of `FileAttribute`.
+pub(crate) fn get_default_generation() -> u64 {
+    0
 }

--- a/templates/fuse_driver.rs.j2
+++ b/templates/fuse_driver.rs.j2
@@ -258,7 +258,7 @@ where
                 reply.entry(
                     &ttl.unwrap_or(default_ttl),
                     &fuse_attr,
-                    fuser::Generation(generation.unwrap_or(get_random_generation())),
+                    fuser::Generation(generation.unwrap_or(get_default_generation())),
                 );
             {% endcall %}
         }
@@ -399,7 +399,7 @@ where
                         reply.created(
                             &ttl.unwrap_or(default_ttl),
                             &fuse_attr,
-                            fuser::Generation(generation.unwrap_or(get_random_generation())),
+                            fuser::Generation(generation.unwrap_or(get_default_generation())),
                             fuser::FileHandle(file_handle.as_raw()),
                             response_flags,
                         );
@@ -965,7 +965,7 @@ where
                             &name,
                             &ttl.unwrap_or(default_ttl),
                             &fuse_attr,
-                            fuser::Generation(generation.unwrap_or(get_random_generation())),
+                            fuser::Generation(generation.unwrap_or(get_default_generation())),
                         ) {
                             dir_iter.push_front((name, ino, file_attr.clone()));
                             if new_offset > 0 {

--- a/tests/test_cd_non_existent_subdir.rs
+++ b/tests/test_cd_non_existent_subdir.rs
@@ -1,0 +1,122 @@
+#![cfg(any(feature = "serial", feature = "parallel"))]
+
+#[cfg(all(feature = "parallel", not(feature = "serial")))]
+use easy_fuser::fuse_parallel::prelude::*;
+use easy_fuser::fuse_presets::DefaultFuseHandler;
+use easy_fuser::fuse_presets::mirror_fs::*;
+#[cfg(feature = "serial")]
+use easy_fuser::fuse_serial::prelude::*;
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+
+struct MyFs {
+    mirror_fs: MirrorFs,
+    default_fs: DefaultFuseHandler<PathBuf>,
+}
+
+impl FuseHandler for MyFs {
+    type TId = PathBuf;
+
+    easy_fuser::delegate_fs! { mirror_fs, [ // readonly functions
+        flush, fsync, lseek, read, release,
+        access, getattr, getxattr, listxattr, lookup, open, readdir, readlink,
+        ]
+    }
+    easy_fuser::delegate_fs! { mirror_fs, [ // readwrite functions
+        copy_file_range, fallocate, write,
+        create, mkdir, mknod, removexattr, rename, rmdir, setattr, setxattr, symlink, unlink
+        ]
+    }
+
+    easy_fuser::delegate_fs! {default_fs, [ bmap, forget, fsyncdir, getlk, ioctl, link, opendir, releasedir, setlk, statfs ]}
+}
+
+static MOUNT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn test_cd_non_existing_subdir_io_error() {
+    let _lock = MOUNT_LOCK.lock().unwrap();
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Trace)
+        .try_init();
+
+    // Create temporary directories for mount point and source
+    let mount_dir = TempDir::new().unwrap();
+    let source_dir = TempDir::new().unwrap();
+
+    let mntpoint = mount_dir.path().to_path_buf();
+    let source_path = source_dir.path().to_path_buf();
+
+    // Create a directory 'debug' in source_path
+    let source_debug = source_path.join("debug");
+    fs::create_dir(&source_debug).unwrap();
+
+    let mntpoint_clone = mntpoint.clone();
+    let source_path_clone = source_path.clone();
+    let handle = std::thread::spawn(move || {
+        let fs = MyFs {
+            mirror_fs: MirrorFs::new(source_path_clone),
+            default_fs: DefaultFuseHandler::new(),
+        };
+        mount(fs, &mntpoint_clone, &[], Some(4)).unwrap();
+    });
+
+    let mnt_debug = mntpoint.join("debug");
+    let mut mounted = false;
+    for _ in 0..100 {
+        if mnt_debug.exists() {
+            mounted = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(mounted, "Mount timed out");
+
+    {
+        // Run bash with LC_ALL=C to ensure English error messages
+        let output = std::process::Command::new("bash")
+            .env("LC_ALL", "C")
+            .arg("-c")
+            .arg(format!("cd {}/debug && sleep 2 && cd asd; ls", mntpoint.display()))
+            .output()
+            .expect("failed to execute bash command");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        println!("bash stdout: {}", stdout);
+        println!("bash stderr: {}", stderr);
+        println!("bash status: {:?}", output.status);
+
+        // Check if we hit the Input/output error
+        let has_io_error = stderr.contains("Input/output error");
+        assert!(!has_io_error, "Detected Input/output error in stderr!");
+    }
+
+    // Unmount
+    eprintln!("Unmounting filesystem...");
+    let mut unmounted = false;
+    for cmd_name in &["fusermount3", "fusermount", "umount"] {
+        let mut cmd = std::process::Command::new(cmd_name);
+        if cmd_name == &"umount" {
+            cmd.arg(&mntpoint);
+        } else {
+            cmd.arg("-u").arg(&mntpoint);
+        }
+        if let Ok(status) = cmd.status() {
+            if status.success() {
+                eprintln!("Unmounted successfully using {}", cmd_name);
+                unmounted = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        unmounted,
+        "Failed to unmount using fusermount3, fusermount, or umount"
+    );
+    handle.join().unwrap();
+}


### PR DESCRIPTION
Fix #55 by fixing the ttl generation from fix to random

## Explanation

1. Did it make sense that the generation was random?

No, it did not make sense to return a different random number on every LOOKUP.

In FUSE (and filesystem design in general), the generation number is meant to be a stable property of an active inode's lifecycle. Its purpose is to help the kernel detect when an inode number has been recycled (i.e., when a file with inode X is deleted, and a newly created file later reuse the same inode X).

  * How it should work: The generation number should remain completely constant for the entire lifetime of that file/directory. It should only change (e.g., increment) if the file is deleted and the inode number is reused for a new file.

  * The bug in easy_fuser: Because the generation number was not cached/tracked per-inode, easy_fuser was calling get_random_generation() to generate a new random number on every single lookup response. This meant that during dentry re-validation (when the 1-second TTL expired), the kernel got a different generation number (G2 != G1) for the same active directory. The kernel interpreted this change as "the directory was deleted and a new one took its place," causing it to invalidate the active working directory dentry.

2. What is the advice according to FUSE standard practices?

According to FUSE protocol specifications and Linux VFS guidelines:

  * NFS Export Support: Generation numbers are only strictly required if the FUSE filesystem is exported over NFS. NFS clients use a combination of the inode number and the generation number to build file handles. If you do not support NFS export, generation numbers are not strictly needed.

  * The Default Practice: If a filesystem does not track generation numbers, it should return a constant value (typically 0 or 1). In FUSE, 0 is a very common default placeholder. Returning a constant ensures that the kernel knows the inode has not changed during re-validation.

  * If tracking is needed: If the filesystem does recycle inode numbers and wants to support NFS exports, it must explicitly track and store the generation number alongside the inode or path (e.g., in a database or in-memory map), ensuring it is stable for the lifetime of the file and only changes when recycled.