### PR TITLE
Revise README for not production ready warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![dependency status](https://deps.rs/repo/github/Alogani/easy_fuser/status.svg)](https://deps.rs/repo/github/Alogani/easy_fuser)
 
 > [!IMPORTANT]
+> This crate is a school project and should not be considered production ready until proven otherwise, keep in mind and have fun !
 > **Breaking Changes in v0.5.0**: The crate has been reorganized to support separate code generation structures per mode.
 > - Instead of a single prelude (`easy_fuser::prelude`), use the mode-specific preludes: `easy_fuser::fuse_serial::prelude::*`, `easy_fuser::fuse_parallel::prelude::*`, or `easy_fuser::fuse_async::prelude::*`.
 > - Template/Preset implementations (like `DefaultFuseHandler` and `MirrorFs`) are now located in the `easy_fuser::fuse_presets` module (instead of `easy_fuser::templates`).


### PR DESCRIPTION
Hi @DocJade ,

Just watched your [video](https://www.youtube.com/watch?v=cTPBGZcTRqo&pp=ygURZG9jIGphZGUgZmFjdG9yaW8%3D) about your own filesystem ! Nice work man, you are impressive.

Because you mentionned Fuse, and i know there is only a few rust crate implementing it, i wondered "How, what did he chooses ?", i looked at your repo and saw fuse_mt, i thought "Makes sense, more mature project". Then i saw you mentionned the issue about [easy_fuser](https://github.com/Alogani/easy_fuser) crate that i created and i was like "OOOPS" ! My project is not clearly production ready and i will modify it as such through this PR !

And it was just one line of code bug about a TTL value i set as default without knowing what i did.

So honestly, just one word, SORRY MAN, and continue to have fun ;-)